### PR TITLE
global: webuser removal and relative import

### DIFF
--- a/invenio_access/control.py
+++ b/invenio_access/control.py
@@ -30,21 +30,22 @@ from invenio.config import CFG_SITE_ADMIN_EMAIL, CFG_SITE_LANG, CFG_SITE_RECORD
 from invenio.ext import principal
 from invenio.ext.sqlalchemy import db
 from invenio.legacy.dbquery import run_sql, truncate_table
-from invenio_access.firerole import (
-    acc_firerole_check_user, compile_role_definition, deserialize,
-    load_role_definition, serialize
-)
-from invenio_access.local_config import (
-    CFG_ACC_ACTIVITIES_URLS, CFG_ACC_EMPTY_ROLE_DEFINITION_SER,
-    CFG_ACC_EMPTY_ROLE_DEFINITION_SRC, DEF_AUTHS, DEF_ROLES, DEF_USERS,
-    DELEGATEADDUSERROLE, SUPERADMINROLE
-)
-from invenio_access.models import AccACTION, AccAuthorization, \
-    UserAccROLE
 
 from six import iteritems
 
 from sqlalchemy.exc import ProgrammingError
+
+from .firerole import (
+    acc_firerole_check_user, compile_role_definition, deserialize,
+    load_role_definition, serialize
+)
+from .local_config import (
+    CFG_ACC_ACTIVITIES_URLS, CFG_ACC_EMPTY_ROLE_DEFINITION_SER,
+    CFG_ACC_EMPTY_ROLE_DEFINITION_SRC, DEF_AUTHS, DEF_ROLES, DEF_USERS,
+    DELEGATEADDUSERROLE, SUPERADMINROLE
+)
+from .models import AccACTION, AccAuthorization, \
+    UserAccROLE
 
 
 def acc_add_action(name_action='', description='', optional='no',

--- a/invenio_access/engine.py
+++ b/invenio_access/engine.py
@@ -17,19 +17,24 @@
 
 """Invenio Access Control Engine in mod_python."""
 
-__revision__ = "$Id$"
-
 import cgi
-from urllib import quote
 
-from .control import acc_find_possible_roles, acc_is_user_in_any_role, acc_get_roles_emails
-from .local_config import CFG_WEBACCESS_WARNING_MSGS, CFG_WEBACCESS_MSGS
-from invenio.legacy.webuser import collect_user_info
-from invenio_access.firerole import load_role_definition, acc_firerole_extract_emails
 from flask_login import current_user
 
+from invenio.ext.login import UserInfo
 
-def acc_authorize_action(req, name_action, authorized_if_no_roles=False, batch_args=False, **arguments):
+from invenio_access.firerole import acc_firerole_extract_emails, \
+    load_role_definition
+
+from urllib import quote
+
+from .control import acc_find_possible_roles, acc_get_roles_emails, \
+    acc_is_user_in_any_role
+from .local_config import CFG_WEBACCESS_MSGS, CFG_WEBACCESS_WARNING_MSGS
+
+
+def acc_authorize_action(req, name_action, authorized_if_no_roles=False,
+                         batch_args=False, **arguments):
     """
     Given the request object (or the user_info dictionary, or the uid), checks
     if the user is allowed to run name_action with the given parameters.
@@ -50,11 +55,13 @@ def acc_authorize_action(req, name_action, authorized_if_no_roles=False, batch_a
         user_info = req
     elif type(req) not in [int, long]:
         uid = current_user.get_id()
-        user_info = collect_user_info(uid)  # FIXME
+        user_info = UserInfo(uid)  # FIXME
     else:
-        user_info = collect_user_info(req)
+        user_info = current_user
 
-    roles_list = acc_find_possible_roles(name_action, always_add_superadmin=True, batch_args=batch_args, **arguments)
+    roles_list = acc_find_possible_roles(name_action,
+                                         always_add_superadmin=True,
+                                         batch_args=batch_args, **arguments)
 
     if not batch_args:
         roles_list = [roles_list]
@@ -62,22 +69,29 @@ def acc_authorize_action(req, name_action, authorized_if_no_roles=False, batch_a
     result = []
     for roles in roles_list:
         if acc_is_user_in_any_role(user_info, roles):
-            ## User belong to at least one authorized role
-            ## or User is SUPERADMIN
+            # User belong to at least one authorized role
+            # or User is SUPERADMIN
             ret_val = (0, CFG_WEBACCESS_WARNING_MSGS[0])
         elif len(roles) <= 1:
             ## No role is authorized for the given action/arguments
             if authorized_if_no_roles:
-                ## User is authorized because no authorization exists for the given
-                ## action/arguments
+                # User is authorized because no authorization exists for the
+                # given action/arguments
                 ret_val = (0, CFG_WEBACCESS_WARNING_MSGS[0])
             else:
-                ## User is not authorized.
-                ret_val = (20, CFG_WEBACCESS_WARNING_MSGS[20] % cgi.escape(name_action))
+                # User is not authorized.
+                ret_val = (
+                    20,
+                    CFG_WEBACCESS_WARNING_MSGS[20] % cgi.escape(name_action)
+                )
         else:
-            ## User is not authorized
+            # User is not authorized
             in_a_web_request_p = bool(user_info.get('uri', ''))
-            ret_val = (1, "%s %s" % (CFG_WEBACCESS_WARNING_MSGS[1], (in_a_web_request_p and "%s %s" % (CFG_WEBACCESS_MSGS[0] % quote(user_info.get('uri', '')), CFG_WEBACCESS_MSGS[1]) or "")))
+            ret_val = (1, "%s %s" % (
+                CFG_WEBACCESS_WARNING_MSGS[1],
+                (in_a_web_request_p and "%s %s" % (
+                    CFG_WEBACCESS_MSGS[0] % quote(user_info.get('uri', '')),
+                    CFG_WEBACCESS_MSGS[1]) or "")))
         result.append(ret_val)
     # FIXME removed CERN specific hack!
     return result if batch_args else result[0]
@@ -90,15 +104,17 @@ def acc_get_authorized_emails(name_action, **arguments):
     This is a best effort operation, because if a role is authorized and
     happens to be defined using a FireRole rule based on regular expression
     or on IP addresses, non every email might be returned.
-    @param name_action: the name of the action.
-    @type name_action: string
-    @param arguments: the arguments to the action.
-    @return: the list of authorized emails.
-    @rtype: set of string
+    :param name_action: the name of the action.
+    :type name_action: string
+    :param arguments: the arguments to the action.
+    :return: the list of authorized emails.
+    :rtype: set of string
     """
-    roles = acc_find_possible_roles(name_action, always_add_superadmin=False, **arguments)
+    roles = acc_find_possible_roles(name_action, always_add_superadmin=False,
+                                    **arguments)
     authorized_emails = acc_get_roles_emails(roles)
     for id_role in roles:
         firerole = load_role_definition(id_role)
-        authorized_emails = authorized_emails.union(acc_firerole_extract_emails(firerole))
+        authorized_emails = authorized_emails.union(
+            acc_firerole_extract_emails(firerole))
     return authorized_emails

--- a/invenio_access/engine.py
+++ b/invenio_access/engine.py
@@ -23,13 +23,12 @@ from flask_login import current_user
 
 from invenio.ext.login import UserInfo
 
-from invenio_access.firerole import acc_firerole_extract_emails, \
-    load_role_definition
-
 from urllib import quote
 
 from .control import acc_find_possible_roles, acc_get_roles_emails, \
     acc_is_user_in_any_role
+from .firerole import acc_firerole_extract_emails, \
+    load_role_definition
 from .local_config import CFG_WEBACCESS_MSGS, CFG_WEBACCESS_WARNING_MSGS
 
 

--- a/invenio_access/firerole.py
+++ b/invenio_access/firerole.py
@@ -30,16 +30,15 @@ import time
 from invenio.base.globals import cfg
 from invenio.ext.logging import register_exception
 from invenio.legacy.dbquery import blob_to_string, run_sql
-from invenio_access.local_config import \
-    CFG_ACC_EMPTY_ROLE_DEFINITION_OBJ, \
-    CFG_ACC_EMPTY_ROLE_DEFINITION_SER, \
-    CFG_ACC_EMPTY_ROLE_DEFINITION_SRC
-
 from six.moves import cPickle
 
 from zlib import compress, decompress
 
 from .errors import InvenioWebAccessFireroleError
+from .local_config import \
+    CFG_ACC_EMPTY_ROLE_DEFINITION_OBJ, \
+    CFG_ACC_EMPTY_ROLE_DEFINITION_SER, \
+    CFG_ACC_EMPTY_ROLE_DEFINITION_SRC
 
 
 __revision__ = "$Id$"

--- a/invenio_access/firerole.py
+++ b/invenio_access/firerole.py
@@ -258,7 +258,7 @@ def acc_firerole_check_user(user_info, firerole_def_obj):
     Given a user_info dictionary, it matches the rules inside the deserialized
     compiled definition in order to discover if the current user match the roles
     corresponding to this definition.
-    :param user_info: a dict produced by collect_user_info which contains every
+    :param user_info: a dict produced by UserInfo(uid) which contains every
     info about a user
     :param firerole_def_obj: a compiled deserialized definition produced by
     compile_role_defintion

--- a/invenio_access/models.py
+++ b/invenio_access/models.py
@@ -26,10 +26,9 @@ from datetime import datetime, timedelta
 from invenio.ext.passlib.hash import mysql_aes_decrypt, mysql_aes_encrypt
 from invenio.ext.sqlalchemy import db
 from invenio.ext.sqlalchemy.utils import session_manager
-from invenio_access.local_config import CFG_ACC_ACTIVITIES_URLS, \
-    SUPERADMINROLE
-from invenio_accounts.models import User
 from invenio.utils.hash import md5
+
+from invenio_accounts.models import User
 
 from random import random
 
@@ -37,6 +36,8 @@ from sqlalchemy.orm import validates
 
 from .errors import InvenioWebAccessMailCookieDeletedError, \
     InvenioWebAccessMailCookieError
+from .local_config import CFG_ACC_ACTIVITIES_URLS, \
+    SUPERADMINROLE
 
 
 class AccACTION(db.Model):

--- a/tests/test_firerole.py
+++ b/tests/test_firerole.py
@@ -29,7 +29,6 @@ acc_firerole_check_user = lazy_import('invenio_access.firerole:acc_firerole_chec
 compile_role_definition = lazy_import('invenio_access.firerole:compile_role_definition')
 deserialize = lazy_import('invenio_access.firerole:deserialize')
 serialize = lazy_import('invenio_access.firerole:serialize')
-collect_user_info = lazy_import('invenio.legacy.webuser:collect_user_info')
 
 
 class AccessControlFireRoleTest(InvenioTestCase):
@@ -37,10 +36,11 @@ class AccessControlFireRoleTest(InvenioTestCase):
 
     def setUp(self):
         """setting up helper variables for tests"""
+        from invenio.ext.login import UserInfo
         self.user_info = {'email' : 'foo.bar@cern.ch', 'uid': 1000,
             'group' : ['patata', 'cetriolo'], 'remote_ip' : '127.0.0.1',
             'guest' : '0'}
-        self.guest = collect_user_info(None)
+        self.guest = UserInfo(None)
 
     def test_compile_role_definition_empty(self):
         """firerole - compiling empty role definitions"""


### PR DESCRIPTION
* INCOMPATIBLE Removes legacy WebUser module.
  (addresses inveniosoftware/invenio#3233)
  (addresses inveniosoftware/invenio#3267)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>