### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/.travis.invenio.cfg
+++ b/.travis.invenio.cfg
@@ -33,5 +33,5 @@ PACKAGES = [
     'invenio_access',
     'invenio_accounts',
     'invenio_upgrader',
-    'invenio.base',
+    'invenio_base',
 ]

--- a/invenio_access/firerole.py
+++ b/invenio_access/firerole.py
@@ -27,7 +27,7 @@ import sys
 
 import time
 
-from invenio.base.globals import cfg
+from invenio_base.globals import cfg
 from invenio.ext.logging import register_exception
 from invenio.legacy.dbquery import blob_to_string, run_sql
 from six.moves import cPickle

--- a/invenio_access/local_config.py
+++ b/invenio_access/local_config.py
@@ -25,8 +25,8 @@ __revision__ = \
 # pylint: disable=C0301
 
 from invenio.config import CFG_SITE_NAME, CFG_SITE_URL, CFG_SITE_SECURE_URL, CFG_SITE_SUPPORT_EMAIL, CFG_SITE_RECORD, CFG_SITE_ADMIN_EMAIL
-from invenio.base.i18n import _
-from invenio.base.globals import cfg as config
+from invenio_base.i18n import _
+from invenio_base.globals import cfg as config
 
 # VALUES TO BE EXPORTED
 # CURRENTLY USED BY THE FILES access_control_engine.py modules.access.control.py webaccessadmin_lib.py

--- a/invenio_access/scripts/authaction.py
+++ b/invenio_access/scripts/authaction.py
@@ -2,7 +2,7 @@
 # -*- mode: python; coding: utf-8; -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011 CERN.
+# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2010, 2011, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -26,7 +26,7 @@ __revision__ = "$Id$"
 
 import sys
 
-from invenio.base.helpers import with_app_context
+from invenio_base.helpers import with_app_context
 
 
 def usage(code, msg=''):

--- a/invenio_access/scripts/webaccessadmin.py
+++ b/invenio_access/scripts/webaccessadmin.py
@@ -1,6 +1,6 @@
 # This file is part of Invenio.
 # Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-# 2012, 2013, 2014 CERN.
+# 2012, 2013, 2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -23,7 +23,7 @@ __revision__ = "$Id$"
 import getopt
 import sys
 
-from invenio.base.helpers import with_app_context
+from invenio_base.helpers import with_app_context
 
 def usage(exitcode=1, msg=""):
     """Prints usage info."""
@@ -56,7 +56,7 @@ def main():
     from invenio_access.firerole import repair_role_definitions
     from invenio_access.control import (acc_add_default_settings,
                                                 acc_reset_default_settings)
-    from invenio.base.globals import cfg
+    from invenio_base.globals import cfg
     from invenio.legacy.bibsched.bibtask import authenticate
 
     DEF_DEMO_USER_ROLES = cfg.get('DEF_DEMO_USER_ROLES', tuple())

--- a/invenio_access/views/admin.py
+++ b/invenio_access/views/admin.py
@@ -27,8 +27,8 @@ from flask_breadcrumbs import register_breadcrumb
 
 from flask_login import login_required
 
-from invenio.base.decorators import sorted_by, templated
-from invenio.base.i18n import _
+from invenio_base.decorators import sorted_by, templated
+from invenio_base.i18n import _
 from invenio.ext.principal import permission_required
 from invenio_access.models import AccACTION, AccROLE
 from invenio_accounts.models import User

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -23,4 +23,5 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ requirements = [
     'wtforms-alchemy>=0.13.1',
     'WTForms>=2.0.1',
     'invenio-accounts>=0.1.2',
+    'invenio-base>=0.2.1',
     'invenio-upgrader>=0.1.0',
 ]
 
@@ -61,6 +62,7 @@ test_requirements = [
 
 
 class PyTest(TestCommand):
+
     """PyTest Test."""
 
     user_options = [('pytest-args=', 'a', "Arguments to pass to py.test")]

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -19,7 +19,7 @@
 
 """Unit tests for Access Mail Cookies."""
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
 
 Model_parser = lazy_import('invenio.modules.jsonalchemy.parser:ModelParser')

--- a/tests/test_firerole.py
+++ b/tests/test_firerole.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013 CERN.
+# Copyright (C) 2007, 2008, 2009, 2010, 2011, 2013, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -22,7 +22,7 @@
 __revision__ = "$Id$"
 
 
-from invenio.base.wrappers import lazy_import
+from invenio_base.wrappers import lazy_import
 from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
 
 acc_firerole_check_user = lazy_import('invenio_access.firerole:acc_firerole_check_user')


### PR DESCRIPTION
* FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>