### PR TITLE
upgrader: upgrade recipe fix

### DIFF
--- a/invenio_access/upgrades/access_2015_05_06_accROLE_accACTION_accARGUMENT_id.py
+++ b/invenio_access/upgrades/access_2015_05_06_accROLE_accACTION_accARGUMENT_id.py
@@ -70,7 +70,9 @@ def do_upgrade():
         CHANGE COLUMN "id_accARGUMENT" "id_accARGUMENT" INT(15) NULL ,
         CHANGE COLUMN "argumentlistid" "argumentlistid" MEDIUMINT(8) NULL ,
         ADD COLUMN "id" INT(15) UNSIGNED NOT NULL AUTO_INCREMENT,
-        DROP PRIMARY KEY,
+        DROP KEY id_accROLE,
+        DROP KEY id_accACTION,
+        DROP KEY id_accARGUMENT,
         ADD PRIMARY KEY ("id");
         """)
 


### PR DESCRIPTION
* FIX Drops the keys from `accROLE_accACTION_accARGUMENT` one by one as.

Signed-off-by: Esteban J. G. Gabancho <esteban.gabancho@gmail.com>