### PR TITLE
tests: fix pytest >=2.8.0 breaking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ python:
 
 before_install:
   - "travis_retry pip install --upgrade pip"
-  - "travis_retry pip install mock twine wheel coveralls"
+  - "travis_retry pip install check-manifest mock twine wheel coveralls"
   - "python requirements.py --extras=$REXTRAS --level=min > .travis-lowest-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=pypi > .travis-release-requirements.txt"
   - "python requirements.py --extras=$REXTRAS --level=dev > .travis-devel-requirements.txt"
@@ -63,6 +63,7 @@ before_script:
   - "inveniomanage database create --quiet"
 
 script:
+  - "check-manifest --ignore .travis-\\*-requirements.txt"
   - "sphinx-build -qnN docs docs/_build/html"
   - "python setup.py test"
 

--- a/invenio_access/models.py
+++ b/invenio_access/models.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta
 from invenio_ext.passlib.hash import mysql_aes_decrypt, mysql_aes_encrypt
 from invenio_ext.sqlalchemy import db
 from invenio_ext.sqlalchemy.utils import session_manager
-from invenio.utils.hash import md5
+from invenio_utils.hash import md5
 
 from invenio_accounts.models import User
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,6 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_access --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_access --cov-report=term-missing
 pep8ignore =
     tests/* ALL

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -25,6 +25,7 @@
 -e git+git://github.com/inveniosoftware/invenio-accounts.git#egg=invenio-accounts
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
--e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
 -e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+-e git+git://github.com/inveniosoftware/invenio-utils.git#egg=invenio-utils
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -26,3 +26,5 @@
 -e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base
 -e git+git://github.com/inveniosoftware/invenio-ext.git#egg=invenio-ext
 -e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader
+-e git+git://github.com/inveniosoftware/invenio-testing.git#egg=invenio-testing
+

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ test_requirements = [
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
     'unittest2>=1.1.0',
+    'invenio-testing>=0.1.0',
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,10 @@ requirements = [
 
 test_requirements = [
     'Flask-Testing>=0.4.1',
-    'coverage>=3.7.1',
-    'pytest-cov>=1.8.1',
+    'coverage>=4.0.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.7.0',
+    'pytest>=2.8.0',
     'unittest2>=1.1.0',
 ]
 
@@ -90,9 +90,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ requirements = [
     'invenio-base>=0.2.1',
     'invenio-ext>=0.1.0',
     'invenio-upgrader>=0.1.0',
+    'invenio-utils>=0.1.0',
 ]
 
 test_requirements = [

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -20,7 +20,7 @@
 """Unit tests for Access Mail Cookies."""
 
 from invenio_base.wrappers import lazy_import
-from invenio.testsuite import InvenioTestCase, make_test_suite, run_test_suite
+from invenio_testsuite import InvenioTestCase
 
 Model_parser = lazy_import('invenio.modules.jsonalchemy.parser:ModelParser')
 
@@ -70,9 +70,3 @@ class TestAccMailCookie(InvenioTestCase):
         assert isinstance(load_cookie.id, long)
 
         self.delete_objects([cookie])
-
-
-TEST_SUITE = make_test_suite(TestAccMailCookie)
-
-if __name__ == '__main__':
-    run_test_suite(TEST_SUITE)

--- a/tests/test_firerole.py
+++ b/tests/test_firerole.py
@@ -23,7 +23,7 @@ __revision__ = "$Id$"
 
 
 from invenio_base.wrappers import lazy_import
-from invenio.testsuite import make_test_suite, run_test_suite, InvenioTestCase
+from invenio_testing import InvenioTestCase
 
 acc_firerole_check_user = lazy_import('invenio_access.firerole:acc_firerole_check_user')
 compile_role_definition = lazy_import('invenio_access.firerole:compile_role_definition')
@@ -201,8 +201,3 @@ class AccessControlFireRoleTest(InvenioTestCase):
             compile_role_definition("deny guest '1'\ndeny all")))
         self.assertEqual(False, acc_firerole_check_user(self.user_info,
             compile_role_definition("deny guest '0'\ndeny all")))
-
-TEST_SUITE = make_test_suite(AccessControlFireRoleTest,)
-
-if __name__ == "__main__":
-    run_test_suite(TEST_SUITE)


### PR DESCRIPTION
* FIX pytest 2.8.0 removed functionality used for tests. This removes
  calls to the removed functions.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>