### PR TITLE
upgrades: fix for possibly missing primary key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,7 @@ cache:
 
 env:
   - REQUIREMENTS=lowest REXTRAS=docs,tests
-  # Temporary disable release requirements until new Invenio version has been
-  # release:
-  #- REQUIREMENTS=release REXTRAS=docs,test
+  - REQUIREMENTS=release REXTRAS=docs,tests
   - REQUIREMENTS=devel REXTRAS=docs,tests
 
 python:

--- a/invenio_access/upgrades/access_2015_06_25_id_accARGUMENT_from_zero_to_null.py
+++ b/invenio_access/upgrades/access_2015_06_25_id_accARGUMENT_from_zero_to_null.py
@@ -19,7 +19,7 @@
 
 """Replace zero value for id_accARGUMENT with NULL."""
 
-from invenio.legacy.dbquery import run_sql
+from invenio_ext.sqlalchemy import db
 
 
 depends_on = [u'access_2015_05_06_accROLE_accACTION_accARGUMENT_id']
@@ -32,7 +32,7 @@ def info():
 
 def do_upgrade():
     """Implement your upgrades here."""
-    run_sql("""
+    db.engine.execute("""
         UPDATE "accROLE_accACTION_accARGUMENT"
         SET "id_accARGUMENT" = NULL
         WHERE "id_accARGUMENT" = 0
@@ -41,10 +41,10 @@ def do_upgrade():
 
 def estimate():
     """Estimate running time of upgrade in seconds (optional)."""
-    total = run_sql("""
+    total = db.engine.execute("""
         SELECT count(*) FROM "accROLE_accACTION_accARGUMENT"
         WHERE "id_accARGUMENT" = 0
-    """)
+    """).fetchall()
     return total[0][0] // 1000 + 1
 
 


### PR DESCRIPTION
* BETTER Makes upgrade recipe resilient to missing primary key in
  accROLE_accACTION_accARGUMENT table.  (closes #10)

Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>