### PR TITLE
access: model refactoring

### DIFF
--- a/invenio_access/api.py
+++ b/invenio_access/api.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Provide API-callable functions for access management."""
+
+from intbitset import intbitset
+
+from invenio_accounts.models import User, Usergroup, UserUsergroup
+
+from invenio_base.globals import cfg
+
+from invenio_ext import principal
+from invenio_ext.sqlalchemy import db
+
+from six import iteritems
+
+from . import models
+from .local_config import DEF_AUTHS, DEF_ROLES, DEF_USERS, SUPERADMINROLE
+
+
+def get_action_roles(id_action):
+    """Return all the roles connected with an action."""
+    id_superadmin_role = models.AccROLE.factory(name=SUPERADMINROLE).id
+    return models.AccAuthorization.query.filter(db.or_(
+        models.AccAuthorization.id_accACTION == id_action,
+        models.AccAuthorization.id_accROLE == id_superadmin_role
+    )).distinct().all()
+
+
+def get_roles_emails(id_roles):
+    """Get emails by roles."""
+    return set(
+        map(lambda u: u.email.lower().strip(),
+            db.session.query(db.func.distinct(User.email)).join(
+                User.active_roles
+            ).filter(
+                models.UserAccROLE.id_accROLE.in_(id_roles)).all()))
+
+
+def find_possible_roles(name_action, always_add_superadmin=True,
+                        batch_args=False, **arguments):
+    """Find all the possible roles that are enabled to a given action.
+
+    :return: roles as a list of role_id
+    """
+    query_roles_without_args = \
+        db.select([models.AccAuthorization.id_accROLE], db.and_(
+            models.AccAuthorization.argumentlistid <= 0,
+            models.AccAuthorization.id_accACTION == db.bindparam('id_action')))
+
+    query_roles_with_args = \
+        models.AccAuthorization.query.filter(db.and_(
+            models.AccAuthorization.argumentlistid > 0,
+            models.AccAuthorization.id_accACTION == db.bindparam('id_action')
+        )).join(models.AccAuthorization.argument)
+
+    id_action = db.session.query(models.AccACTION.id).filter(
+        models.AccACTION.name == name_action).scalar()
+    roles = intbitset(db.engine.execute(query_roles_without_args.params(
+        id_action=id_action)).fetchall())
+
+    if always_add_superadmin:
+        roles.add(cfg["CFG_SUPERADMINROLE_ID"] or 1)
+
+    # Unpack arguments
+    if batch_args:
+        batch_arguments = [dict(zip(arguments.keys(), values))
+                           for values in zip(*arguments.values())]
+    else:
+        batch_arguments = [arguments]
+
+    acc_authorizations = query_roles_with_args.params(
+        id_action=id_action
+    ).all()
+
+    result = []
+    for arguments in batch_arguments:
+        batch_roles = roles.copy()
+        for auth in acc_authorizations:
+            if auth.id_accROLE not in batch_roles:
+                if not ((auth.argument.value != arguments.get(
+                    auth.argument.keyword, '*') != '*'
+                ) and auth.argument.value != '*'):
+                    batch_roles.add(auth.id_accROLE)
+        result.append(batch_roles)
+    return result if batch_args else result[0]
+
+
+def reset_default_settings(superusers=(),
+                           additional_def_user_roles=(),
+                           additional_def_roles=(),
+                           additional_def_auths=()):
+    """reset to default by deleting everything and adding default.
+
+    superusers - list of superuser emails
+
+    additional_def_user_roles - additional list of pair email, rolename
+    (see DEF_DEMO_USER_ROLES in access_control_config.py)
+
+    additional_def_roles - additional list of default list of roles
+    (see DEF_DEMO_ROLES in access_control_config.py)
+
+    additional_def_auths - additional list of default authorizations
+    (see DEF_DEMO_AUTHS in access_control_config.py)
+    """
+    remove = delete_all_settings()
+    add = add_default_settings(
+        superusers, additional_def_user_roles,
+        additional_def_roles, additional_def_auths)
+
+    return remove, add
+
+
+def add_default_users(users, usergroups, userusergroups):
+    """Add default useris, usergroups and userusergroups."""
+    # add users
+    for user_tuple in users:
+        if User.exists(User.email == user_tuple[1]):
+            # update
+            user = User.query.filter_by(email=user_tuple[1]).first()
+            user.nickname = user_tuple[0]
+            user.password = user_tuple[2]
+            user.note = user_tuple[3]
+            db.session.merge(user)
+        else:
+            # insert
+            user = User(nickname=user_tuple[0],
+                        email=user_tuple[1],
+                        password=user_tuple[2],
+                        note=user_tuple[3])
+            db.session.add(user)
+        db.session.commit()
+    # add usergroups
+    for usergroup_tuple in usergroups:
+        if Usergroup.exists(Usergroup.name == usergroup_tuple[0]):
+            # update
+            usergroup = Usergroup.query.filter_by(
+                name=usergroup_tuple[0]).first()
+            usergroup.description = usergroup_tuple[1]
+            db.session.merge(usergroup)
+        else:
+            # insert
+            usergroup = Usergroup(name=usergroup_tuple[0],
+                                  description=usergroup_tuple[1])
+            db.session.add(usergroup)
+        db.session.commit()
+    # add userusergroups
+    for userusergroup_tuple in userusergroups:
+        user = User.query.filter_by(nickname=userusergroup_tuple[0]).first()
+        usergroup = Usergroup.query.filter_by(
+            name=userusergroup_tuple[1]).first()
+        uug_filters = [
+            UserUsergroup.id_user == user.id,
+            UserUsergroup.id_usergroup == usergroup.id,
+        ]
+        if UserUsergroup.exists(*uug_filters):
+            # update
+            userusergroup = UserUsergroup.query.filter(*uug_filters).first()
+            userusergroup.user_status = userusergroup_tuple[2]
+            db.session.merge(userusergroup)
+        else:
+            # insert
+            userusergroup = UserUsergroup(id_user=user.id,
+                                          id_usergroup=usergroup.id,
+                                          user_status=userusergroup_tuple[2])
+            db.session.add(userusergroup)
+        db.session.commit()
+
+
+def add_default_settings(superusers=(),
+                         additional_def_user_roles=(),
+                         additional_def_roles=(),
+                         additional_def_auths=()):
+    """Add the default settings if they don't exist.
+
+    :param superusers: list of superuser emails
+    :param additional_def_user_roles: additional list of pair email, rolename
+        (see DEF_DEMO_USER_ROLES in access_control_config.py)
+    :param additional_def_roles: additional list of default list of roles
+        (see DEF_DEMO_ROLES in access_control_config.py)
+    :param additional_def_auths: additional list of default authorizations
+        (see DEF_DEMO_AUTHS in access_control_config.py)
+    """
+    # add new superusers
+    for user in superusers:
+        DEF_USERS.append(user)
+
+    # ensure admin is in default users
+    if cfg['CFG_SITE_ADMIN_EMAIL'] not in DEF_USERS:
+        DEF_USERS.append(cfg['CFG_SITE_ADMIN_EMAIL'])
+
+    # add roles
+
+    insroles = []
+    # define dictiory with default roles
+    def_roles = dict([(role[0], role[1:]) for role in DEF_ROLES])
+    def_roles.update(
+        dict([(role[0], role[1:]) for role in additional_def_roles]))
+    # insert new roles
+    for name, (description, firerole_def_src) in iteritems(def_roles):
+        # try to add, don't care if description is different
+        role = models.AccROLE.factory(
+            name=name,
+            description=description,
+            firerole_def_src=firerole_def_src
+        )
+        insroles.append(role)
+
+    # add users as superadmin (role)
+    users = User.query.filter(User.email.in_(DEF_USERS)).all()
+    superadmin_role = models.AccROLE.query.filter_by(name=SUPERADMINROLE).one()
+    insuserroles = []
+    for user in users:
+        useraccrole = models.UserAccROLE.factory(
+            id_user=user.id,
+            id_accROLE=superadmin_role.id
+        )
+        insuserroles.append(useraccrole)
+
+    # add additional roles to the users
+    for user_email, role_name in additional_def_user_roles:
+        user = User.query.filter(User.email == user_email).one()
+        role = models.AccROLE.query.filter(
+            models.AccROLE.name == role_name).one()
+        useraccrole = models.UserAccROLE.factory(
+            id_user=user.id,
+            id_accROLE=role.id
+        )
+        insuserroles.append(useraccrole)
+
+    # add actions
+    insactions = []
+    for principal_action in principal.actions:
+        action = models.AccACTION.factory(
+            name=principal_action.name,
+            description=principal_action.description,
+            optional=principal_action.optional,
+            allowedkeywords=principal_action.allowedkeywords
+        )
+        insactions.append(action)
+
+    # add authorizations
+    insauths = []
+    def_auths = list(DEF_AUTHS) + list(additional_def_auths)
+    for (name_role, name_action, args) in def_auths:
+        action = models.AccACTION.query.filter_by(name=name_action).one()
+        role = models.AccROLE.query.filter_by(name=name_role).one()
+
+        # add arguments
+        arguments = []
+        for (key, value) in args.iteritems():
+            arguments.append(models.AccARGUMENT.factory(
+                keyword=key,
+                value=value
+            ))
+        # add the authorization
+        auth = models.AccAuthorization.factory(
+            role=role,
+            action=action,
+            arguments=arguments
+        )
+        insauths.append(auth)
+
+    return insroles, insactions, insuserroles, insauths
+
+
+def delete_all_settings():
+    """Remove all data affiliated with webaccess.
+
+    simply remove all data affiliated with webaccess by truncating
+    tables accROLE, accACTION, accARGUMENT and those connected.
+    """
+    from invenio_ext.sqlalchemy import db
+    db.session.commit()
+
+    models.AccROLE.delete()
+    models.AccACTION.delete()
+    models.AccARGUMENT.delete()
+    models.UserAccROLE.delete()
+    models.AccAuthorization.delete()

--- a/invenio_access/bases.py
+++ b/invenio_access/bases.py
@@ -17,51 +17,44 @@
 # along with Invenio; if not, write to the Free Software Foundation, Inc.,
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
-"""
-    invenio.models.access.bases
-    ---------------------------
+"""JSONAlchemy model extension.
 
-    JSONAlchemy model extension.
+example of a document base::
 
-    example of a document base::
-
-        bases:
-            invenio_access.bases.AclFactory('doc')
+    bases:
+        invenio_access.bases.AclFactory('doc')
 """
 
 import six
 
 from flask_login import current_user
 
+from .access import models
 from .engine import acc_authorize_action
-from .control import acc_is_user_in_role, acc_get_role_id
-from .firerole import compile_role_definition, acc_firerole_check_user
-from .local_config import SUPERADMINROLE, CFG_WEBACCESS_WARNING_MSGS
+from .firerole import acc_firerole_check_user, compile_role_definition
+from .local_config import CFG_WEBACCESS_WARNING_MSGS, SUPERADMINROLE
 
 
 def AclFactory(obj=''):
-    """Creates access control behavior extension for JSONAlchemy model.
+    """Create access control behavior extension for JSONAlchemy model.
 
     :param obj: name of action object (e.g. check 'viewrestrdoc' where
         'viewrestr' is action and 'doc' is `obj`)
     :return: JSONAlchemy class extesion
         (note: it has to return class not instance)
     """
-
     class Acl(object):
-        """
-        Access controled behavior for JSONAlchemy models.
-        """
+
+        """Access controled behavior for JSONAlchemy models."""
 
         def is_authorized(self, user_info=None, action='viewrestr'):
-            """Check if the user is authorized to perform the action with the
-            given restrictions.
+            """Check if the user is authorized to perform the action.
 
             This method is able to run *pre* and *post* hooks to extend its
             functionality,
             e.g. :class:`~invenio_records.bases:DocumentsHooks`
 
-        .. note::
+            .. note::
 
                 If the object has embed restrictions it will override the
                 access right of the parent. For example in
@@ -85,7 +78,11 @@ def AclFactory(obj=''):
             if restriction is None:
                 return (1, 'Missing restriction')
 
-            if acc_is_user_in_role(user_info, acc_get_role_id(SUPERADMINROLE)):
+            if models.UserAccROLE.is_user_in_any_role(
+                user_info=user_info,
+                id_roles=[
+                    models.AccROLE.factory(name=SUPERADMINROLE).id]
+            ):
                 return (0, CFG_WEBACCESS_WARNING_MSGS[0])
 
             is_authorized = (0, CFG_WEBACCESS_WARNING_MSGS[0])
@@ -116,8 +113,11 @@ def AclFactory(obj=''):
                                          '%s in order to access this document'
                                          % repr(auth_value))
                 elif auth_type == 'role':
-                    if not acc_is_user_in_role(user_info,
-                                               acc_get_role_id(auth_value)):
+                    if not models.UserAccROLE.is_user_in_any_role(
+                        user_info=user_info,
+                        id_roles=[r.id for r in models.AccROLE.factory(
+                            name=auth_value)]
+                    ):
                         is_authorized = (1, 'You must be member in the role %s'
                                          ' in order to access this document' %
                                          repr(auth_value))

--- a/invenio_access/errors.py
+++ b/invenio_access/errors.py
@@ -1,5 +1,6 @@
 # This file is part of Invenio.
-# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2014 CERN.
+# Copyright (C) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012,
+#               2014, 2015 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -18,9 +19,14 @@
 """Define access exceptions."""
 
 
+class AccessFactoryError(Exception):
+
+    """If there is an error on factory calling."""
+
+
 class InvenioWebAccessFireroleError(Exception):
 
-    """Just an Exception to discover if it's a FireRole problem"""
+    """Just an Exception to discover if it's a FireRole problem."""
 
 
 class InvenioWebAccessMailCookieError(Exception):

--- a/invenio_access/mailcookie.py
+++ b/invenio_access/mailcookie.py
@@ -28,9 +28,10 @@ derive from the base class and add specific bits.
 from datetime import datetime, timedelta
 
 from invenio_ext.sqlalchemy import db
+from invenio_accounts.models import User
 
 from .errors import InvenioWebAccessMailCookieError
-from .models import AccMAILCOOKIE, User
+from .models import AccMAILCOOKIE, AccROLE, UserAccROLE
 
 _datetime_format = "%Y-%m-%d %H:%M:%S"
 
@@ -51,8 +52,7 @@ def mail_cookie_create_common(kind, params, cookie_timeout=timedelta(days=1),
 def mail_cookie_create_role(role_name, role_timeout=timedelta(hours=3),
                             cookie_timeout=timedelta(days=1), onetime=True):
     """Create a unique url to belong temporaly to a role."""
-    from .control import acc_get_role_id
-    assert(acc_get_role_id(role_name) != 0)
+    assert AccROLE.exists(AccROLE == role_name)
     kind = 'role'
     params = (role_name, role_timeout)
     return mail_cookie_create_common(kind, params, cookie_timeout, onetime)
@@ -112,18 +112,16 @@ def mail_cookie_check_role(cookie, uid):
 
     Temporarily add the given uid to the role specified.
     """
-    from .control import acc_get_role_id, acc_add_user_role
     try:
         (kind, params) = mail_cookie_check_common(cookie)
         assert kind == 'role'
         (role_name, role_timeout) = params
-        role_id = acc_get_role_id(role_name)
-        assert role_id != 0
+        role = AccROLE.factory(name=role_name)
         assert type(role_timeout) is timedelta
     except (TypeError, AssertionError, StandardError):
         raise InvenioWebAccessMailCookieError
     expiration = (datetime.today()+role_timeout).strftime(_datetime_format)
-    acc_add_user_role(uid, role_id, expiration=expiration)
+    UserAccROLE.factory(id_user=uid, id_accROLE=role.id, expiration=expiration)
     return (role_name, expiration)
 
 
@@ -142,7 +140,7 @@ def mail_cookie_check_pw_reset(cookie):
 
 def mail_cookie_check_mail_activation(cookie):
     """Check a mail activation cookie for a valid authorization."""
-    #try:
+    # try:
     (kind, email) = mail_cookie_check_common(cookie)
     assert(kind == 'mail_activation')
     user = db.session.query(User.query.filter_by(email=email).exists())
@@ -151,8 +149,8 @@ def mail_cookie_check_mail_activation(cookie):
     else:
         raise InvenioWebAccessMailCookieError(
             "email '%s' doesn't exist" % email)
-        #except (TypeError, AssertionError):
-        #raise InvenioWebAccessMailCookieError
+        # except (TypeError, AssertionError):
+        # raise InvenioWebAccessMailCookieError
 
 
 def mail_cookie_check_authorize_action(cookie):

--- a/invenio_access/models.py
+++ b/invenio_access/models.py
@@ -19,24 +19,33 @@
 
 """Access database models."""
 
+from __future__ import unicode_literals
+
 from cPickle import dumps, loads
 
 from datetime import datetime, timedelta
 
+from invenio_accounts.models import User
+
 from invenio_ext.passlib.hash import mysql_aes_decrypt, mysql_aes_encrypt
 from invenio_ext.sqlalchemy import db
 from invenio_ext.sqlalchemy.utils import session_manager
-from invenio_utils.hash import md5
 
-from invenio_accounts.models import User
+from invenio_utils.hash import md5
 
 from random import random
 
-from sqlalchemy.orm import validates
+from six import iteritems, text_type
 
-from .errors import InvenioWebAccessMailCookieDeletedError, \
-    InvenioWebAccessMailCookieError
+from sqlalchemy.orm import validates
+from sqlalchemy.orm.exc import NoResultFound
+
+from .errors import AccessFactoryError, \
+    InvenioWebAccessMailCookieDeletedError, InvenioWebAccessMailCookieError
+from .firerole import acc_firerole_check_user, \
+    compile_role_definition, deserialize, serialize
 from .local_config import CFG_ACC_ACTIVITIES_URLS, \
+    CFG_ACC_EMPTY_ROLE_DEFINITION_SER, CFG_ACC_EMPTY_ROLE_DEFINITION_SRC, \
     SUPERADMINROLE
 
 
@@ -49,13 +58,133 @@ class AccACTION(db.Model):
                    primary_key=True, autoincrement=True)
     name = db.Column(db.String(32), unique=True, nullable=True)
     description = db.Column(db.String(255), nullable=True)
-    allowedkeywords = db.Column(db.String(255), nullable=True)
-    optional = db.Column(db.Enum('yes', 'no', name='yes_no'), nullable=False,
-                         server_default='no')
+    _allowedkeywords = db.Column(db.String(255), nullable=True,
+                                 name="allowedkeywords")
+    _optional = db.Column(db.Enum('yes', 'no', name='yes_no'), nullable=False,
+                          server_default='no', name="optional")
+
+    def __init__(self, allowedkeywords=None, *args, **kwargs):
+        """Init."""
+        self.allowedkeywords = allowedkeywords or []
+        super(AccACTION, self).__init__(*args, **kwargs)
 
     def __repr__(self):
         """Repr."""
         return "{0.name}".format(self)
+
+    @db.hybrid_property
+    def allowedkeywords(self):
+        """Get allowedkeywords."""
+        return self._allowedkeywords.split(u',') \
+            if self._allowedkeywords else []
+
+    @allowedkeywords.setter
+    def allowedkeywords(self, value):
+        """Set allowedkeywords.
+
+        Note: if value chage, then delete connected authorizations.
+        """
+        # set new value (accept string or list)
+        if not isinstance(value, str) and not isinstance(value, text_type):
+            value = text_type.join(u',', sorted(value))
+
+        if self.id and self._allowedkeywords != value:
+            # delete authorizations
+            filters = [AccAuthorization.id_accACTION == self.id]
+            if value:
+                filters.append(
+                    db.or_(
+                        AccAuthorization.id_accARGUMENT != -1,
+                        AccAuthorization.id_accARGUMENT.is_(None)
+                    )
+                )
+            AccAuthorization.delete(*filters)
+
+        self._allowedkeywords = value
+
+    @db.hybrid_property
+    def optional(self):
+        """Get optional."""
+        return self._optional
+
+    @optional.setter
+    def optional(self, value):
+        """Set optional.
+
+        note: if value change to no, then delete connected authorizations.
+        """
+        if self.id and self._optional != value and value == 'no':
+            AccAuthorization.delete(*[
+                AccAuthorization.id_accACTION == self.id,
+                AccAuthorization.id_accARGUMENT == -1,
+                AccAuthorization.argumentlistid == -1,
+            ])
+
+        # set new value
+        self._optional = value
+
+    def is_optional(self):
+        """Return True if it's optional."""
+        return True if self.optional == 'yes' else False
+
+    @classmethod
+    @session_manager
+    def delete(cls, *criteria, **filters):
+        """Delete action."""
+        objs = cls.query.filter(*criteria).filter_by(**filters).all()
+        for obj in objs:
+            db.session.delete(obj)
+
+    @classmethod
+    @session_manager
+    def update(cls, criteria, updates):
+        """Update values.
+
+        :param criteria: filter list
+        :param updates: list of update
+        """
+        objs = cls.query.filter(*criteria).all()
+        for obj in objs:
+            for (k, v) in iteritems(updates):
+                obj.__setattr__(k, v)
+            db.session.merge(obj)
+
+    @classmethod
+    def count(cls, *criteria, **filters):
+        """Count how much actions."""
+        return cls.query.filter(*criteria).filter_by(**filters).count()
+
+    @classmethod
+    @session_manager
+    def factory(cls, name, description=None, optional=None,
+                allowedkeywords=None):
+        """Create or update a action.
+
+        :return: a AccACTION
+        """
+        if not name:
+            raise AccessFactoryError
+        optional = 'yes' if bool(optional) else 'no'
+        try:
+            action = AccACTION.query.filter(
+                AccACTION.name == name).one()
+            if description:
+                action.description = description
+            if optional:
+                action.optional = optional
+            if allowedkeywords:
+                action.allowedkeywords = allowedkeywords
+            db.session.merge(action)
+        except NoResultFound:
+            action = AccACTION(
+                name=name,
+                description=description,
+                optional=optional,
+                allowedkeywords=allowedkeywords
+            )
+            db.session.add(action)
+
+        return action
 
 
 class AccARGUMENT(db.Model):
@@ -72,6 +201,43 @@ class AccARGUMENT(db.Model):
     def __repr__(self):
         """Repr."""
         return "{0.keyword}={0.value}".format(self)
+
+    @classmethod
+    @session_manager
+    def delete(cls, *criteria, **filters):
+        """Delete argument."""
+        objs = cls.query.filter(*criteria).filter_by(**filters).all()
+        for obj in objs:
+            db.session.delete(obj)
+
+    @classmethod
+    def exists(cls, *criteria, **filters):
+        """Check if authorization exists."""
+        return db.session.query(
+            cls.query.filter(*criteria).filter_by(**filters).exists()
+        ).scalar()
+
+    @classmethod
+    @session_manager
+    def factory(cls, keyword=None, value=None):
+        """Add new or get existing argument.
+
+        :param keyword: if add new, set keyword, or use to filter
+        :param value: if add new, set value, or use to filter
+        :return: a AccARGUMENT
+        """
+        if not keyword:
+            raise AccessFactoryError
+        try:
+            argument = AccARGUMENT.query.filter(
+                AccARGUMENT.keyword == keyword,
+                AccARGUMENT.value == value
+            ).one()
+        except NoResultFound:
+            argument = AccARGUMENT(keyword=keyword, value=value)
+            db.session.add(argument)
+
+        return argument
 
 
 class AccMAILCOOKIE(db.Model):
@@ -160,12 +326,101 @@ class AccROLE(db.Model):
                    autoincrement=True)
     name = db.Column(db.String(32), unique=True, nullable=True)
     description = db.Column(db.String(255), nullable=True)
-    firerole_def_ser = db.Column(db.iBinary, nullable=True)
-    firerole_def_src = db.Column(db.Text, nullable=True)
+    _firerole_def_ser = db.Column(db.iBinary, nullable=True,
+                                  name="firerole_def_ser")
+    _firerole_def_src = db.Column(db.Text, nullable=True,
+                                  name="firerole_def_src")
 
     def __repr__(self):
         """Repr."""
         return "{0.name} - {0.description}".format(self)
+
+    @db.hybrid_property
+    def firerole_def_ser(self):
+        """Get firerole_def_ser."""
+        return deserialize(self._firerole_def_ser)
+
+    @firerole_def_ser.setter
+    def firerole_def_ser(self, value):
+        """Ensure to not directly set the compiled version."""
+        raise Exception("Can't set attribute. Please set firerole_def_src "
+                        "value")
+
+    @db.hybrid_property
+    def firerole_def_src(self):
+        """Get firerole_def_src."""
+        return self._firerole_def_src
+
+    @firerole_def_src.setter
+    def firerole_def_src(self, value):
+        """Set firerole_def_src."""
+        # update compiled version
+        compiled_version = serialize(compile_role_definition(value))
+        self._firerole_def_ser = bytearray(compiled_version) \
+            if compiled_version is not None \
+            else CFG_ACC_EMPTY_ROLE_DEFINITION_SER
+        # set new value
+        self._firerole_def_src = value
+
+    @classmethod
+    @session_manager
+    def delete(cls, *criteria, **filters):
+        """Delete role."""
+        # delete objects
+        objs = cls.query.filter(*criteria).filter_by(**filters).all()
+        for obj in objs:
+            db.session.delete(obj)
+
+    @classmethod
+    @session_manager
+    def update(cls, criteria, updates):
+        """Update values.
+
+        :param criteria: filter list
+        :param updates: list of update
+        """
+        objs = cls.query.filter(*criteria).all()
+        for obj in objs:
+            for (k, v) in iteritems(updates):
+                obj.__setattr__(k, v)
+            db.session.merge(obj)
+
+    @classmethod
+    @session_manager
+    def factory(cls, name, description=None,
+                firerole_def_src=None):
+        """Add (and insert in DB if already not exists) a new role.
+
+        :param name: role name
+        :param description: role description
+        :param firerole_def_src: firewall definition
+        :return: the new role
+        """
+        if not name:
+            raise AccessFactoryError
+        try:
+            role = AccROLE.query.filter_by(name=name).one()
+            if description:
+                role.description = description
+            if firerole_def_src:
+                role.firerole_def_src = firerole_def_src
+            db.session.merge(role)
+        except NoResultFound:
+            firerole_def_src = firerole_def_src or \
+                CFG_ACC_EMPTY_ROLE_DEFINITION_SRC
+
+            role = AccROLE(name=name,
+                           description=description,
+                           firerole_def_src=firerole_def_src)
+            db.session.add(role)
+        return role
+
+    @classmethod
+    def exists(cls, *criteria, **filters):
+        """Check if role exists."""
+        return db.session.query(
+            cls.query.filter(*criteria).filter_by(**filters).exists()
+        ).scalar()
 
 
 class AccAuthorization(db.Model):
@@ -181,12 +436,23 @@ class AccAuthorization(db.Model):
     id_accACTION = db.Column(db.Integer(15, unsigned=True),
                              db.ForeignKey(AccACTION.id), nullable=True,
                              index=True)
-    _id_accARGUMENT = db.Column(db.Integer(15), nullable=True,
-                                name="id_accARGUMENT", index=True)
+    _id_accARGUMENT = db.Column(db.Integer(15),
+                                nullable=True, name="id_accARGUMENT",
+                                index=True)
     argumentlistid = db.Column(db.MediumInteger(8), nullable=True)
 
-    role = db.relationship(AccROLE, backref='authorizations')
-    action = db.relationship(AccACTION, backref='authorizations')
+    role = db.relationship(
+        AccROLE,
+        backref=db.backref(
+            'authorizations',
+            cascade="all, delete-orphan",
+        ))
+    action = db.relationship(
+        AccACTION,
+        backref=db.backref(
+            'authorizations',
+            cascade="all, delete-orphan",
+        ))
     argument = db.relationship(
         AccARGUMENT, backref='authorizations',
         primaryjoin=db.and_(
@@ -209,6 +475,120 @@ class AccAuthorization(db.Model):
         """set id_accARGUMENT."""
         self._id_accARGUMENT = value or None
 
+    @classmethod
+    @session_manager
+    def delete(cls, *criteria, **filters):
+        """Delete authorization."""
+        objs = cls.query.filter(*criteria).filter_by(**filters).all()
+        for obj in objs:
+            db.session.delete(obj)
+
+    @classmethod
+    def exists(cls, *criteria, **filters):
+        """Check if authorization exists."""
+        return db.session.query(
+            cls.query.filter(*criteria).filter_by(**filters).exists()
+        ).scalar()
+
+    @classmethod
+    def count(cls, *criteria, **filters):
+        """Count how much authorizations."""
+        return cls.query.filter(*criteria).filter_by(**filters).count()
+
+    @classmethod
+    @session_manager
+    def _factory(cls, role, action, argumentlistid=-1, id_accARGUMENT=-1):
+        """Simply create or update authorization without special control."""
+        basic_filters = [
+            AccAuthorization.id_accROLE == role.id,
+            AccAuthorization.id_accACTION == action.id,
+        ]
+        # ready to add/read
+        try:
+            # get auth
+            return [AccAuthorization.query.filter(*(
+                basic_filters + [
+                    AccAuthorization.argumentlistid == argumentlistid,
+                    AccAuthorization._id_accARGUMENT == id_accARGUMENT
+                ])).one()]
+        except NoResultFound:
+            # create new
+            auth = AccAuthorization(
+                id_accROLE=role.id,
+                id_accACTION=action.id,
+                argumentlistid=argumentlistid,
+                id_accARGUMENT=id_accARGUMENT
+            )
+            db.session.add(auth)
+            return [auth]
+
+    @classmethod
+    def factory(cls, role, action, argumentlistid=-1, arguments=None):
+        """Create or update a authorization.
+
+        :param role: role associated
+        :param action: action associated
+        :param arglistid: argumentlistid for the inserted entries
+            if -1: create new group
+            other values: add to this group, if it exists or not
+        :param arguments: list of arguments
+        """
+        basic_filters = [
+            AccAuthorization.id_accROLE == role.id,
+            AccAuthorization.id_accACTION == action.id,
+        ]
+        if action.is_optional():
+            return cls._factory(role=role, action=action, argumentlistid=-1,
+                                id_accARGUMENT=-1)
+        if not action.allowedkeywords:
+            return cls._factory(role=role, action=action, argumentlistid=0,
+                                id_accARGUMENT=None)
+        # check all the arguments if someone is not allowed
+        if arguments:
+            for argument in arguments:
+                if argument.keyword not in action.allowedkeywords:
+                    raise AccessFactoryError("Not permitted argument.")
+        if argumentlistid < 0:
+            # list id arguments
+            argument_ids = [a.id for a in arguments]
+            # check if equal authorization exists
+            for argumentlistid in db.session.query(
+                AccAuthorization.argumentlistid).filter(
+                    *basic_filters).distinct().all():
+                # list length
+                listlength = AccAuthorization.count(*(
+                    basic_filters + [
+                        AccAuthorization.argumentlistid == argumentlistid,
+                        AccAuthorization._id_accARGUMENT.in_(argument_ids)
+                    ]))
+                # not list
+                notlist = AccAuthorization.count(*(
+                    basic_filters + [
+                        AccAuthorization.argumentlistid == argumentlistid,
+                        AccAuthorization._id_accARGUMENT.notin_(argument_ids)
+                    ]))
+                # this means that a duplicate already exists
+                if not notlist and listlength == len(argument_ids):
+                    return []
+            # find new arglistid, highest + 1
+            argumentlistid = db.session.query(
+                db.func.max(AccAuthorization.argumentlistid)).filter(
+                    *basic_filters
+                ).scalar() or 1
+        # all references are valid, insert: one entry in raa for each argument
+        auths = []
+        for argument_id in argument_ids:
+            auth = AccAuthorization(
+                id_accROLE=role.id,
+                id_accACTION=action.id,
+                argumentlistid=argumentlistid,
+                id_accARGUMENT=None
+            )
+            db.session.add(auth)
+            auths.append(auth)
+
+        return auths
+
 
 class UserAccROLE(db.Model):
 
@@ -223,8 +603,115 @@ class UserAccROLE(db.Model):
     expiration = db.Column(db.DateTime, nullable=False,
                            server_default='9999-12-31 23:59:59')
 
-    user = db.relationship(User, backref='roles')
-    role = db.relationship(AccROLE, backref='users')
+    user = db.relationship(
+        User,
+        backref=db.backref(
+            'roles',
+            cascade="all, delete-orphan",
+        )
+    )
+    role = db.relationship(
+        AccROLE,
+        backref=db.backref(
+            'users',
+            cascade="all, delete-orphan",
+        )
+    )
+
+    @classmethod
+    @session_manager
+    def delete(cls, *criteria, **filters):
+        """Delete useraccrole."""
+        objs = cls.query.filter(*criteria).filter_by(**filters).all()
+        for obj in objs:
+            db.session.delete(obj)
+
+    @classmethod
+    @session_manager
+    def update(cls, criteria, updates):
+        """Update values.
+
+        :param criteria: filter list
+        :param updates: list of update
+        """
+        objs = cls.query.filter(*criteria).all()
+        for obj in objs:
+            for (k, v) in iteritems(updates):
+                obj.__setattr__(k, v)
+            db.session.merge(obj)
+
+    @classmethod
+    def count(cls, *criteria, **filters):
+        """Count how much authorizations."""
+        return cls.query.filter(*criteria).filter_by(**filters).count()
+
+    @classmethod
+    @session_manager
+    def factory(cls, id_user, id_accROLE, expiration=None):
+        """Add (and insert in DB if already not exists) a new role.
+
+        :param id_user: user id
+        :param id_accROLE: role id
+        :param expiration: datetime of new expiration (if create new)
+        :return: the UserAccROLE
+        """
+        expiration = expiration or datetime.strptime(
+            '9999-12-31 23:59', '%Y-%m-%d %H:%M')
+        try:
+            # get one
+            user_acc_role = UserAccROLE.query.filter_by(
+                id_user=id_user, id_accROLE=id_accROLE
+            ).one()
+            # update expiration
+            if user_acc_role.expiration < expiration:
+                user_acc_role.expiration = expiration
+                db.session.merge(user_acc_role)
+        except NoResultFound:
+            # insert new
+            user_acc_role = UserAccROLE(
+                id_user=id_user, id_accROLE=id_accROLE, expiration=expiration
+            )
+            db.session.add(user_acc_role)
+
+        return user_acc_role
+
+    @classmethod
+    def get_roles_emails(cls, id_roles):
+        """Get emails by roles.
+
+        :param id_roles: list of roles
+        :return: list of user's email that have at least one of these roles
+        """
+        return set(
+            map(lambda u: u.email.lower().strip(),
+                db.session.query(
+                    db.func.distinct(User.email)).join(
+                        User.active_roles
+                    ).filter(UserAccROLE.id_accROLE.in_(id_roles)).all()))
+
+    @classmethod
+    def is_user_in_any_role(cls, user_info, id_roles):
+        """Check if the user have at least one of that roles.
+
+        :param user_info: user info (id, ...)
+        :param roles: list of roles
+        :return: True if the user have at least one of that roles
+        """
+        filters = [
+            UserAccROLE.id_user == user_info['uid'],
+            UserAccROLE.expiration >= db.func.now(),
+            UserAccROLE.id_accROLE.in_(id_roles)
+        ]
+
+        if UserAccROLE.count(*filters) > 0:
+            return True
+
+        roles = AccROLE.query.filter(*filters).all()
+        for role in roles:
+            if acc_firerole_check_user(user_info, role.firerole_def_ser):
+                return True
+
+        return False
 
 User.active_roles = db.relationship(
     UserAccROLE,

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,13 +22,13 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-[wheel]
-universal=1
-
 [build_sphinx]
 source-dir = docs/
 build-dir = docs/_build
 all_files = 1
+
+[bdist_wheel]
+universal = 1
 
 [compile_catalog]
 directory = invenio_access/translations/

--- a/tests/test_cookie.py
+++ b/tests/test_cookie.py
@@ -23,7 +23,7 @@ from invenio_base.wrappers import lazy_import
 
 from invenio_testing import InvenioTestCase
 
-Model_parser = lazy_import('invenio.modules.jsonalchemy.parser:ModelParser')
+Model_parser = lazy_import('invenio_jsonalchemy.parser:ModelParser')
 
 TEST_PACKAGE = 'invenio_access.testsuite'
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,1257 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+"""Test for access models."""
+
+from __future__ import unicode_literals
+
+from invenio_testing import InvenioTestCase
+
+
+class UserAccROLETests(InvenioTestCase):
+
+    """Test UserAccROLE class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+        import datetime
+
+        self.user = User(nickname="test-user", email="test-email@test.it",
+                         password="test")
+
+        self.create_objects([self.user])
+
+        # useraccrole
+
+        self.role_uar_1 = AccROLE(name='test-role-uac-1',
+                                  description='test-desc-uac-1')
+        self.role_uar_2 = AccROLE(name='test-role-uac-2',
+                                  description='test-desc-uac-2')
+
+        self.create_objects([self.role_uar_1, self.role_uar_2])
+
+        expiration = datetime.datetime.now()
+        self.useraccroles = [
+            UserAccROLE(id_user=self.user.id, id_accROLE=self.role_uar_1.id,
+                        expiration=expiration),
+            UserAccROLE(id_user=self.user.id, id_accROLE=self.role_uar_2.id,
+                        expiration=expiration),
+        ]
+
+        self.create_objects(self.useraccroles)
+
+        # test factory()
+
+        self.role_factory_1 = AccROLE(name='test-role-factory-1')
+        self.role_factory_2 = AccROLE(name='test-role-factory-2')
+
+        self.create_objects([self.role_factory_1, self.role_factory_2])
+
+        self.userrole_factory_1 = UserAccROLE(
+            id_user=self.user.id,
+            id_accROLE=self.role_factory_1.id,
+            expiration=datetime.datetime.strptime(
+                '9999-12-31 23:59', '%Y-%m-%d %H:%M'))
+
+        yesterday = datetime.date.today() - datetime.timedelta(1)
+        self.userrole_factory_2 = UserAccROLE(
+            id_user=self.user.id,
+            id_accROLE=self.role_factory_2.id,
+            expiration=yesterday)
+
+        self.create_objects([self.userrole_factory_1, self.userrole_factory_2])
+
+        # count(), tests
+
+        self.counts_roles = [
+            AccROLE(
+                name='test-counts-role-uac-'+str(i)
+            ) for i in range(1, 6)]
+        self.create_objects(self.counts_roles)
+
+        self.counts_useraccroles = [
+            UserAccROLE(
+                id_user=self.user.id,
+                id_accROLE=self.counts_roles[i-1].id
+            ) for i in range(1, 6)]
+        self.create_objects(self.counts_useraccroles)
+
+        # test is_user_in_any_role()
+
+        self.iuiar_role = AccROLE(name="test-is-user-in-any-role")
+        self.create_objects([self.iuiar_role])
+
+        self.iuiar_useraccrole = UserAccROLE(
+            id_user=self.user.id,
+            id_accROLE=self.iuiar_role.id,
+            expiration=datetime.date.today() + datetime.timedelta(1)
+        )
+        self.create_objects([self.iuiar_useraccrole])
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.delete_objects([self.user])
+        self.delete_objects([self.role_uar_1, self.role_uar_2])
+        self.delete_objects(self.useraccroles)
+        self.delete_objects([
+            self.role_factory_1, self.role_factory_2,
+            self.userrole_factory_1, self.userrole_factory_2])
+        self.delete_objects(self.counts_roles)
+        self.delete_objects(self.counts_useraccroles)
+        self.delete_objects([self.iuiar_role, self.iuiar_useraccrole])
+
+    def test_useraccrole_bulk_update(self):
+        """Test update multiple useraccroles."""
+        from invenio_access.models import UserAccROLE
+        import datetime
+        new_expiration = datetime.datetime.now() + datetime.timedelta(days=1)
+        old_expiration = self.useraccroles[0].expiration
+        id_user = self.useraccroles[0].id_user
+        id_accrole_0 = self.useraccroles[0].id_accROLE
+        id_accrole_1 = self.useraccroles[1].id_accROLE
+
+        criteria = [
+            UserAccROLE.id_user == id_user,
+            UserAccROLE.id_accROLE.in_([
+                self.useraccroles[0].id_accROLE,
+            ])
+        ]
+
+        updates = {
+            'expiration': new_expiration,
+        }
+
+        UserAccROLE.update(criteria, updates)
+
+        useraccrole_0 = UserAccROLE.query.filter_by(
+            id_user=self.useraccroles[0].id_user,
+            id_accROLE=self.useraccroles[0].id_accROLE).first()
+        useraccrole_1 = UserAccROLE.query.filter_by(
+            id_user=self.useraccroles[1].id_user,
+            id_accROLE=self.useraccroles[1].id_accROLE).first()
+
+        # test expiration changed for useraccrole 0
+        assert useraccrole_0.expiration.day == new_expiration.day
+
+        # test expiration not changed for useraccrole 1
+        assert useraccrole_1.expiration.day == old_expiration.day
+
+        # test not changed
+        assert useraccrole_0.id_user == id_user
+        assert useraccrole_1.id_user == id_user
+        assert useraccrole_0.id_accROLE == id_accrole_0
+        assert useraccrole_1.id_accROLE == id_accrole_1
+
+    def test_factory(self):
+        """Test factory."""
+        from invenio_access.models import UserAccROLE
+        import datetime
+
+        # test get userrole that already exists (not expired)
+        userrole = UserAccROLE.factory(
+            id_user=self.userrole_factory_1.id_user,
+            id_accROLE=self.userrole_factory_1.id_accROLE,
+            expiration=datetime.datetime.now()
+        )
+        assert userrole.id_user == self.userrole_factory_1.id_user
+        assert userrole.id_accROLE == self.userrole_factory_1.id_accROLE
+        assert userrole.expiration == self.userrole_factory_1.expiration
+
+        # test get userrole that already exists (expired)
+        userrole = UserAccROLE.factory(
+            id_user=self.userrole_factory_2.id_user,
+            id_accROLE=self.userrole_factory_2.id_accROLE,
+            expiration=datetime.datetime.now()
+        )
+        assert userrole.id_user == self.userrole_factory_2.id_user
+        assert userrole.id_accROLE == self.userrole_factory_2.id_accROLE
+        assert userrole.expiration == self.userrole_factory_2.expiration
+
+        # test create new userrole
+
+        userrole = UserAccROLE.factory(
+            id_user=self.user.id,
+            id_accROLE=self.role_uar_1.id
+        )
+
+        userrole_loaded = UserAccROLE.query.filter_by(
+            id_user=self.user.id,
+            id_accROLE=self.role_uar_1.id
+        ).first()
+
+        assert userrole_loaded.id_user == self.user.id
+        assert userrole_loaded.id_accROLE == self.role_uar_1.id
+        assert userrole.expiration == userrole.expiration
+        assert userrole.expiration >= datetime.datetime.now()
+
+    def test_count(self):
+        """Test count."""
+        from invenio_access.models import UserAccROLE
+
+        filters = [
+            UserAccROLE.id_user == self.user.id,
+            UserAccROLE.id_accROLE.in_([r.id for r in self.counts_roles])
+        ]
+
+        assert UserAccROLE.count(*filters) == len(self.counts_useraccroles)
+
+    def test_is_user_in_any_role(self):
+        """Test is_user_in_any_role function."""
+        from invenio_access.models import UserAccROLE
+        user_info = {'uid': self.user.id}
+        assert UserAccROLE.is_user_in_any_role(user_info, [self.iuiar_role.id])
+
+        self.delete_objects([self.iuiar_useraccrole])
+        assert not UserAccROLE.is_user_in_any_role(user_info,
+                                                   [self.iuiar_role.id])
+        # TODO test the for each
+
+
+class AccROLETests(InvenioTestCase):
+
+    """Test AccROLE class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccROLE
+        from invenio_access.local_config import SUPERADMINROLE
+
+        # roles
+        self.roles = [
+            AccROLE(name='test-role-1', description='test-desc-1'),
+            AccROLE(name='test-role-2', description='test-desc-2'),
+            AccROLE(name='test-role-3', description='test-desc-3'),
+        ]
+        self.create_objects(self.roles)
+
+        # check firerol_def
+        self.role_firerol_def = AccROLE(
+            name='test-role_firerol_def',
+            firerole_def_src="allow remote_ip '127.0.0.0/24'"
+        )
+        self.role_firerol_def_2 = AccROLE(
+            name='test-role_firerol_def-2',
+            firerole_def_src=None
+        )
+        self.create_objects([self.role_firerol_def, self.role_firerol_def_2])
+
+        # test factory
+
+        self.role_factory = AccROLE(
+            name='test-role_factory-name',
+            description='test-role_factory-description',
+            firerole_def_src="allow remote_ip '127.0.0.0/24'"
+        )
+
+        self.create_objects([self.role_factory])
+
+        # test delete SUPERADMINROLE
+
+        self.role_superadmin = AccROLE(
+            name=SUPERADMINROLE+"-test",
+            description='test-role_factory-description',
+            firerole_def_src="allow remote_ip '127.0.0.0/24'"
+        )
+
+        self.create_objects([self.role_superadmin])
+
+        # test exists()
+
+        self.exists_role = AccROLE(
+            name="test-exists-role",
+            description='test-role_exists-description',
+            firerole_def_src="allow remote_ip '127.0.0.0/24'"
+        )
+
+        self.create_objects([self.exists_role])
+
+        # test firerole_def_ser setter()
+
+        self.firerole_role = AccROLE(
+            name="test-firerole-role",
+            description='test-role_firerole-description',
+        )
+
+        self.create_objects([self.firerole_role])
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.delete_objects(self.roles)
+        self.delete_objects([self.role_firerol_def, self.role_firerol_def_2])
+        self.delete_objects([self.role_factory])
+        self.delete_objects([self.role_superadmin])
+        self.delete_objects([self.exists_role])
+        self.delete_objects([self.firerole_role])
+
+    def test_role_bulk_update(self):
+        """Test update multiple roles."""
+        from invenio_access.models import AccROLE
+        new_description = 'test-desc-modified'
+        old_description = self.roles[2].description
+        name_0 = self.roles[0].name
+        name_1 = self.roles[1].name
+        name_2 = self.roles[2].name
+
+        criteria = [
+            AccROLE.id.in_([self.roles[0].id,
+                            self.roles[1].id])
+        ]
+
+        updates = {
+            'description': new_description,
+        }
+
+        AccROLE.update(criteria, updates)
+
+        rule_0 = AccROLE.query.get(self.roles[0].id)
+        rule_1 = AccROLE.query.get(self.roles[1].id)
+        rule_2 = AccROLE.query.get(self.roles[2].id)
+
+        # test description changed for rule 0,1
+        assert rule_0.description == new_description
+        assert rule_1.description == new_description
+
+        # test description not changed for rule 2
+        assert rule_2.description == old_description
+
+        # test name not changed
+        assert rule_0.name == name_0
+        assert rule_1.name == name_1
+        assert rule_2.name == name_2
+
+    def test_firerol_ser(self):
+        """Test firerole ser."""
+        from invenio_access.models import AccROLE
+        from invenio_access.firerole import \
+            compile_role_definition
+
+        firerole = self.role_firerol_def.firerole_def_src
+        # read from the db
+        id = self.role_firerol_def.id
+        role_from_db = AccROLE.query.get(id)
+        # test
+        assert role_from_db.firerole_def_src == firerole
+        assert role_from_db.firerole_def_ser == \
+            compile_role_definition(firerole)
+
+    def test_firerol_ser_none(self):
+        """Test firerole ser."""
+        from invenio_access.models import AccROLE
+        from invenio_access.firerole import \
+            compile_role_definition
+        firerole = self.role_firerol_def_2.firerole_def_src
+        # read from the db
+        id = self.role_firerol_def_2.id
+        role_from_db = AccROLE.query.get(id)
+        # test
+        assert role_from_db.firerole_def_src == firerole
+        assert role_from_db.firerole_def_ser == \
+            compile_role_definition(firerole)
+
+    def test_factory(self):
+        """Test factory."""
+        from invenio_access.models import AccROLE
+        from invenio_access.local_config import \
+            CFG_ACC_EMPTY_ROLE_DEFINITION_SRC
+
+        # test: get role that already exists
+        role = AccROLE.factory(self.role_factory.name)
+
+        assert role.id == self.role_factory.id
+        assert role.name == self.role_factory.name
+        assert role.description == self.role_factory.description
+        assert role.firerole_def_src == self.role_factory.firerole_def_src
+        assert role.firerole_def_ser == self.role_factory.firerole_def_ser
+
+        # test: create new role (setting description and firerole)
+        name = self.role_factory.name
+        description = "test factory test desc"
+        firerole_def_src = "deny remote_ip '127.0.0.0/24'"
+        self.delete_objects([self.role_factory])
+        role = AccROLE.factory(name=name, description=description,
+                               firerole_def_src=firerole_def_src)
+        assert role.name == name
+        assert role.description == description
+        assert role.firerole_def_src == firerole_def_src
+
+        # test: create new role (with default description and firerole)
+        name = self.role_factory.name
+        self.delete_objects([role])
+        role = AccROLE.factory(name=name)
+
+        assert role.name == name
+        assert role.description is None
+        assert role.firerole_def_src == CFG_ACC_EMPTY_ROLE_DEFINITION_SRC
+
+        self.delete_objects([role])
+
+    def test_exists(self):
+        """Test argument exists."""
+        from invenio_access.models import AccROLE
+        id = self.exists_role.id
+        # test True
+        assert AccROLE.exists(AccROLE.id == id) is True
+        # test False
+        self.delete_objects([self.exists_role])
+        assert AccROLE.exists(AccROLE.id == id) is False
+
+    def test_firerole_setter(self):
+        """Test firerole setter."""
+        self.assertRaises(
+            Exception,
+            setattr,
+            self.firerole_role.firerole_def_ser,
+            "allow remote_ip '127.0.0.0/24'"
+        )
+
+
+class AccARGUMENTTests(InvenioTestCase):
+
+    """Test AccARGUMENT class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccARGUMENT
+
+        # exists() tests
+        self.exists_argument = AccARGUMENT(keyword="fuu", value="bar")
+        self.create_objects([self.exists_argument])
+
+        # factory() tests
+        self.factory_argument = AccARGUMENT(keyword="test-factory-keyword",
+                                            value="test-factory-value")
+        self.create_objects([self.factory_argument])
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.delete_objects([self.exists_argument])
+        self.delete_objects([self.factory_argument])
+
+    def test_argument_exists(self):
+        """Test argument exists."""
+        from invenio_access.models import AccARGUMENT
+        id_arg = self.exists_argument.id
+        # test True
+        assert AccARGUMENT.exists(AccARGUMENT.id == id_arg) is True
+        # test False
+        self.delete_objects([self.exists_argument])
+        assert AccARGUMENT.exists(AccARGUMENT.id == id_arg) is False
+
+    def test_factory(self):
+        """Test factory."""
+        from invenio_access.models import AccARGUMENT
+
+        keyword = self.factory_argument.keyword
+        value = self.factory_argument.value
+
+        # test if argument already exists
+        argument = AccARGUMENT.factory(keyword=keyword, value=value)
+
+        assert argument.id == self.factory_argument.id
+        assert argument.keyword == self.factory_argument.keyword
+        assert argument.value == self.factory_argument.value
+
+        # test if not exists
+        self.delete_objects([self.factory_argument])
+        argument = AccARGUMENT.factory(keyword=keyword, value=value)
+
+        assert argument.keyword == keyword
+        assert argument.value == value
+
+        self.delete_objects([argument])
+
+
+class AccAuthorizationTests(InvenioTestCase):
+
+    """Test AccAuthorization class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccAuthorization, \
+            AccACTION, AccROLE
+        # exists() tests
+        self.exists_auth = AccAuthorization()
+        self.create_objects([self.exists_auth])
+        # counts() tests
+        self.counts_auth = [
+            AccAuthorization(argumentlistid=i) for i in range(1, 6)]
+        self.create_objects(self.counts_auth)
+
+        # factory_with_no_arguments tests
+
+        self.role_fwna = AccROLE(name='test-factory-no-args-role')
+        self.create_objects([self.role_fwna])
+
+        self.actions_fwna = [
+            AccACTION(
+                allowedkeywords='fuu',
+                optional='yes'
+            ),
+            AccACTION(
+                allowedkeywords='fuu',
+                optional='no'
+            ),
+            AccACTION(
+                allowedkeywords='',
+                optional='yes'
+            ),
+            AccACTION(
+                allowedkeywords='',
+                optional='no'
+            ),
+        ]
+        self.create_objects(self.actions_fwna)
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.delete_objects([self.exists_auth])
+        self.delete_objects(self.counts_auth)
+        self.delete_objects(self.actions_fwna)
+        self.delete_objects([self.role_fwna])
+
+    def test_authorization_exists(self):
+        """Test authorization exists."""
+        from invenio_access.models import AccAuthorization
+        id_auth = self.exists_auth.id
+        # test True
+        assert AccAuthorization.exists(AccAuthorization.id == id_auth) is True
+        # test False
+        self.delete_objects([self.exists_auth])
+        assert AccAuthorization.exists(AccAuthorization.id == id_auth) is False
+
+    def test_authorization_count(self):
+        """Test authorization count."""
+        from invenio_access.models import AccAuthorization
+        ids = [auth.id for auth in self.counts_auth]
+        # test True
+        assert AccAuthorization.count(
+            AccAuthorization.argumentlistid < 3,
+            AccAuthorization.id.in_(ids)
+        ) == 2
+        # test False
+        AccAuthorization.query.filter(
+            AccAuthorization.argumentlistid > 1).delete()
+        assert AccAuthorization.count(
+            AccAuthorization.argumentlistid < 3,
+            AccAuthorization.id.in_(ids)
+        ) == 1
+
+    def test_factory_with_no_arguments_1(self):
+        """Test factory with no arguments."""
+        from invenio_access.models import AccAuthorization
+        # factory_with_no_arguments() tests
+        auths = AccAuthorization.factory(
+            role=self.role_fwna,
+            action=self.actions_fwna[0],
+        )
+        assert len(auths) == 1
+        assert auths[0].argumentlistid == -1
+        assert auths[0].id_accARGUMENT == -1
+        self.delete_objects(auths)
+
+    def test_factory_with_no_arguments_2(self):
+        """Test factory with no arguments."""
+        from invenio_access.models import AccAuthorization
+        # factory_with_no_arguments() tests
+        auths = AccAuthorization.factory(
+            role=self.role_fwna,
+            action=self.actions_fwna[3],
+        )
+        assert len(auths) == 1
+        assert auths[0].id_accARGUMENT is None
+        assert auths[0].argumentlistid == 0
+
+        # try again
+        id = auths[0].id
+        id_accROLE = auths[0].id_accROLE
+        id_accACTION = auths[0].id_accACTION
+        id_accARGUMENT = auths[0].id_accARGUMENT
+        argumentlistid = auths[0].argumentlistid
+
+        auths2 = AccAuthorization.factory(
+            role=self.role_fwna,
+            action=self.actions_fwna[3],
+        )
+        assert len(auths2) == 1
+
+        assert auths2[0].id == id
+        assert auths2[0].id_accROLE == id_accROLE
+        assert auths2[0].id_accACTION == id_accACTION
+        assert auths2[0].id_accARGUMENT == id_accARGUMENT
+        assert auths2[0].argumentlistid == argumentlistid
+
+        self.delete_objects(auths)
+        self.delete_objects(auths2)
+
+    def test_factory_with_no_arguments_3(self):
+        """Test factory with no arguments."""
+        from invenio_access.models import AccAuthorization, AccARGUMENT
+        from invenio_access.errors import AccessFactoryError
+        # factory_with_no_arguments() tests
+        self.assertRaises(
+            AccessFactoryError,
+            AccAuthorization.factory,
+            role=self.role_fwna,
+            action=self.actions_fwna[1],
+            argumentlistid=0,
+            arguments=[AccARGUMENT(keyword="nopermitted")]
+        )
+
+
+class AccACTIONTests(InvenioTestCase):
+
+    """Test AccACTION class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccACTION, AccAuthorization
+
+        # bulk update() tests
+
+        self.actions = [
+            AccACTION(name='test-action-1', description='test-desc-1'),
+            AccACTION(name='test-action-2', description='test-desc-2'),
+            AccACTION(name='test-action-3', description='test-desc-3'),
+        ]
+        self.create_objects(self.actions)
+
+        # count(), tests
+
+        self.counts_actions = [
+            AccACTION(
+                name="test-count-action-"+str(i),
+                description='test-count-action'
+            ) for i in range(1, 6)]
+        self.create_objects(self.counts_actions)
+
+        # update allowedkeywords, optional test
+
+        self.action_update = AccACTION(
+            name="test-action-update-allowedkeywords",
+            description='test-action-update-allowedkeywords',
+            allowedkeywords="tochange",
+            optional='yes'
+        )
+        self.action_update_2 = AccACTION(
+            name="test-action-update-optional",
+            description='test-action-update-optional',
+            optional='no'
+        )
+        self.create_objects([self.action_update, self.action_update_2])
+
+        self.auth_update = AccAuthorization(
+            action=self.action_update,
+            id_accARGUMENT=None,
+            argumentlistid=-1
+        )
+        self.auth_update_2 = AccAuthorization(
+            action=self.action_update_2,
+            id_accARGUMENT=-1,
+            argumentlistid=-1
+        )
+        self.auth_update_3 = AccAuthorization(
+            action=self.action_update_2,
+            id_accARGUMENT=None,
+            argumentlistid=-1
+        )
+        self.auth_update_4 = AccAuthorization(
+            action=self.action_update,
+            id_accARGUMENT=-1,
+            argumentlistid=-1
+        )
+        self.create_objects([self.auth_update, self.auth_update_2,
+                             self.auth_update_3, self.auth_update_4])
+
+        # allowedkeywords on new action tests
+
+        self.allowedkeywords_auth_empty = AccAuthorization(
+            id_accACTION=None,
+            id_accARGUMENT=None
+        )
+        self.create_objects([self.allowedkeywords_auth_empty])
+
+        # optional on new action tests
+
+        self.optional_auth_new_obj = AccAuthorization(
+            id_accACTION=None,
+            id_accARGUMENT=-1,
+            argumentlistid=-1
+        )
+        self.create_objects([self.optional_auth_new_obj])
+
+    def tearDown(self):
+        """Run after the tests."""
+        self.delete_objects(self.actions)
+        self.delete_objects(self.counts_actions)
+        self.delete_objects([self.action_update, self.action_update_2,
+                             self.auth_update, self.auth_update_2,
+                             self.auth_update_3, self.auth_update_4])
+        self.delete_objects([self.allowedkeywords_auth_empty])
+        self.delete_objects([self.optional_auth_new_obj])
+
+    def test_set_allowedkeywords_new_action_empty_value(self):
+        """Test allowedkeywords for new action."""
+        from invenio_access.models import AccACTION, AccAuthorization
+        id_auth = self.allowedkeywords_auth_empty.id
+
+        action = AccACTION(
+            name="test-set-allowedkeywords-new-action",
+            allowedkeywords=""
+        )
+        self.create_objects([action])
+        assert AccAuthorization.count(AccAuthorization.id == id_auth) == 1
+        self.delete_objects([action])
+
+    def test_set_allowedkeywords_new_action_not_empty_value(self):
+        """Test allowedkeywords for new action."""
+        from invenio_access.models import AccACTION, AccAuthorization
+        id_auth = self.allowedkeywords_auth_empty.id
+
+        action = AccACTION(
+            name="test-set-allowedkeywords-new-action",
+            allowedkeywords="not-empty-value"
+        )
+        self.create_objects([action])
+        assert AccAuthorization.count(AccAuthorization.id == id_auth) == 1
+        self.delete_objects([action])
+
+    def test_set_optional_set_no(self):
+        """Test set optional on new object: set 'no'."""
+        from invenio_access.models import AccACTION, AccAuthorization
+        id_auth = self.optional_auth_new_obj.id
+
+        action = AccACTION(
+            name="test-set-optional-new-action",
+            optional='no'
+        )
+        self.create_objects([action])
+        assert action.is_optional() is False
+        assert AccAuthorization.count(AccAuthorization.id == id_auth) == 1
+        self.delete_objects([action])
+
+    def test_set_optional_set_yes(self):
+        """Test set optional on new object: set 'yes'."""
+        from invenio_access.models import AccACTION, AccAuthorization
+        id_auth = self.optional_auth_new_obj.id
+
+        action = AccACTION(
+            name="test-set-optional-new-action",
+            optional='yes'
+        )
+        self.create_objects([action])
+        assert action.is_optional() is True
+        assert AccAuthorization.count(AccAuthorization.id == id_auth) == 1
+        self.delete_objects([action])
+
+    def test_action_bulk_update(self):
+        """Test update multiple actions."""
+        from invenio_access.models import AccACTION
+        new_description = 'test-desc-modified'
+        old_description = self.actions[2].description
+        name_0 = self.actions[0].name
+        name_1 = self.actions[1].name
+        name_2 = self.actions[2].name
+
+        criteria = [
+            AccACTION.id.in_([self.actions[0].id,
+                              self.actions[1].id])
+        ]
+
+        updates = {
+            'description': new_description,
+        }
+
+        AccACTION.update(criteria, updates)
+
+        action_0 = AccACTION.query.get(self.actions[0].id)
+        action_1 = AccACTION.query.get(self.actions[1].id)
+        action_2 = AccACTION.query.get(self.actions[2].id)
+
+        # test description changed for action 0,1
+        assert action_0.description == new_description
+        assert action_1.description == new_description
+
+        # test description not changed for action 2
+        assert action_2.description == old_description
+
+        # test name not changed
+        assert action_0.name == name_0
+        assert action_1.name == name_1
+        assert action_2.name == name_2
+
+    def test_actions_count(self):
+        """Test actions count."""
+        from invenio_access.models import AccACTION
+
+        ids = [action.id for action in self.counts_actions]
+        # test True
+        assert AccACTION.count(
+            AccACTION.id.in_(ids)
+        ) == len(self.counts_actions)
+        # test False
+        AccACTION.delete(AccACTION.id.in_(ids))
+        assert AccACTION.count(
+            AccACTION.id.in_(ids)
+        ) == 0
+
+    def test_update_allowedkeyword_1(self):
+        """Test allowedkeywords change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        orig_value = self.action_update.allowedkeywords
+        auth_id = self.auth_update.id
+
+        # set original value
+        self.action_update.allowedkeywords = orig_value
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        orig_value.append("changed")
+        self.action_update.allowedkeywords = orig_value
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 0
+
+    def test_update_allowedkeyword_2(self):
+        """Test allowedkeywords change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        orig_value = self.action_update.allowedkeywords
+        auth_id = self.auth_update_2.id
+
+        # set original value
+        self.action_update.allowedkeywords = orig_value
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        orig_value.append("changed")
+        self.action_update.allowedkeywords = orig_value
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+    def test_update_optional_action_1(self):
+        """Test optional change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        auth_id = self.auth_update.id
+
+        # set original value
+        self.action_update.optional = 'yes'
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        self.action_update.optional = 'no'
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+    def test_update_optional_action_2(self):
+        """Test optional change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        auth_id = self.auth_update.id
+
+        # set original value
+        self.action_update_2.optional = 'no'
+        db.session.merge(self.action_update_2)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        self.action_update_2.optional = 'yes'
+        db.session.merge(self.action_update_2)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+    def test_update_optional_action_3(self):
+        """Test optional change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        auth_id = self.auth_update_3.id
+
+        # set original value
+        self.action_update.optional = 'yes'
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        self.action_update.optional = 'no'
+        db.session.merge(self.action_update)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+    def test_update_optional_action_4(self):
+        """Test optional change."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccAuthorization
+
+        auth_id = self.auth_update_4.id
+
+        # set original value
+        self.action_update_2.optional = 'no'
+        db.session.merge(self.action_update_2)
+        db.session.commit()
+        # test if already exists connected authorization
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+        # set different value
+        self.action_update_2.optional = 'yes'
+        db.session.merge(self.action_update_2)
+        db.session.commit()
+        # test if connected authorization is deleted
+        assert AccAuthorization.count(AccAuthorization.id == auth_id) == 1
+
+    def test_allowedkeywords_string(self):
+        """Test to set string as allowedkeywords."""
+        from invenio_access.models import AccACTION
+
+        keywords_string = 'test,insert,keywords,as,a,string'
+        keywords_list = keywords_string.split(',')
+
+        # create object
+        action = AccACTION(
+            allowedkeywords=keywords_string
+        )
+        assert action.allowedkeywords == keywords_list
+        self.create_objects([action])
+        # test read from db
+        action_read_by_db = AccACTION.query.get(action.id)
+        assert action_read_by_db.allowedkeywords == keywords_list
+
+    def test_allowedkeywords_list(self):
+        """Test to set list as allowedkeywords."""
+        from invenio_access.models import AccACTION
+
+        keywords_string = 'test,insert,keywords,as,a,string'
+        keywords_list = sorted(keywords_string.split(','))
+
+        # create object
+        action = AccACTION(
+            allowedkeywords=keywords_list
+        )
+        assert action.allowedkeywords == keywords_list
+        self.create_objects([action])
+        # test read from db
+        action_read_by_db = AccACTION.query.get(action.id)
+        assert action_read_by_db.allowedkeywords == keywords_list
+
+
+class ModelDeleteTest(InvenioTestCase):
+
+    """Test AccACTION class."""
+
+    def setUp(self):
+        """Run before the test."""
+        from invenio_access.models import AccACTION, \
+            AccAuthorization, AccARGUMENT, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        self.user = User(nickname="test-user", email="test-email@test.it",
+                         password="test")
+
+        self.create_objects([self.user])
+
+        # delete() tests
+
+        self.role = AccROLE(name="test-role")
+        self.action = AccACTION(name="test-action")
+        self.argument = AccARGUMENT(keyword="test-key", value="test-value")
+
+        self.create_objects([self.role, self.action, self.argument])
+
+        self.authorization = AccAuthorization(
+            role=self.role,
+            action=self.action,
+            _id_accARGUMENT=self.argument.id
+        )
+
+        self.create_objects([self.authorization])
+
+        self.useraccrole = UserAccROLE(
+            id_user=self.user.id,
+            id_accROLE=self.role.id)
+
+        self.create_objects([self.useraccrole])
+
+    def tearDown(self):
+        """Run after the tests."""
+        # delete() tests
+        self.delete_objects([self.role, self.action, self.argument,
+                             self.authorization, self.user,
+                             self.useraccrole])
+
+    def test_delete_objects_authorization(self):
+        """Test delete role."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccAuthorization, AccARGUMENT, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        AccAuthorization.delete(AccAuthorization.id == self.authorization.id)
+
+        # assure that role, action, user, useraccrole still exist
+        self.assertTrue(
+            db.session.query(
+                AccROLE.query.filter(
+                    AccROLE.id == self.role.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccACTION.query.filter(
+                    AccACTION.id == self.action.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                User.query.filter(
+                    User.id == self.user.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                UserAccROLE.query.filter(
+                    UserAccROLE.id_user == self.useraccrole.id_user,
+                    UserAccROLE.id_accROLE == self.useraccrole.id_accROLE,
+                ).exists()).scalar())
+
+        # assure that argument is removed
+        self.assertFalse(
+            db.session.query(
+                AccARGUMENT.query.filter(
+                    AccARGUMENT.id == self.argument.id
+                ).exists()).scalar())
+
+    def test_delete_objects_role(self):
+        """Test delete role."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccAuthorization, AccARGUMENT, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        AccROLE.delete(AccROLE.id == self.role.id)
+
+        # assure that action, user still exists
+        self.assertTrue(
+            db.session.query(
+                AccACTION.query.filter(
+                    AccACTION.id == self.action.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                User.query.filter(
+                    User.id == self.user.id
+                ).exists()).scalar())
+
+        # assure that argument, authorization, useraccrole are removed
+        self.assertFalse(
+            db.session.query(
+                AccAuthorization.query.filter(
+                    AccAuthorization.id == self.authorization.id
+                ).exists()).scalar())
+        self.assertFalse(
+            db.session.query(
+                AccARGUMENT.query.filter(
+                    AccARGUMENT.id == self.argument.id
+                ).exists()).scalar())
+        self.assertFalse(
+            db.session.query(
+                UserAccROLE.query.filter(
+                    UserAccROLE.id_user == self.useraccrole.id_user,
+                    UserAccROLE.id_accROLE == self.useraccrole.id_accROLE,
+                ).exists()).scalar())
+
+    def test_delete_objects_action(self):
+        """Test delete role."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccAuthorization, AccARGUMENT, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        AccACTION.delete(AccACTION.id == self.action.id)
+
+        # assure that role, user, useraccrole still exists
+        self.assertTrue(
+            db.session.query(
+                AccROLE.query.filter(
+                    AccROLE.id == self.role.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                User.query.filter(
+                    User.id == self.user.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                UserAccROLE.query.filter(
+                    UserAccROLE.id_user == self.useraccrole.id_user,
+                    UserAccROLE.id_accROLE == self.useraccrole.id_accROLE,
+                ).exists()).scalar())
+
+        # assure that argument and authorization are removed
+        self.assertFalse(
+            db.session.query(
+                AccAuthorization.query.filter(
+                    AccAuthorization.id == self.authorization.id
+                ).exists()).scalar())
+        self.assertFalse(
+            db.session.query(
+                AccARGUMENT.query.filter(
+                    AccARGUMENT.id == self.argument.id
+                ).exists()).scalar())
+
+    def test_delete_objects_argument(self):
+        """Test delete role."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccARGUMENT, AccAuthorization, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        AccARGUMENT.delete(AccARGUMENT.id == self.argument.id)
+
+        # assure that role, action, authorization, user, useraccrole
+        # still exists
+        self.assertTrue(
+            db.session.query(
+                AccROLE.query.filter(
+                    AccROLE.id == self.role.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccACTION.query.filter(
+                    AccACTION.id == self.action.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccAuthorization.query.filter(
+                    AccAuthorization.id == self.authorization.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                User.query.filter(
+                    User.id == self.user.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                UserAccROLE.query.filter(
+                    UserAccROLE.id_user == self.useraccrole.id_user,
+                    UserAccROLE.id_accROLE == self.useraccrole.id_accROLE,
+                ).exists()).scalar())
+
+    def test_delete_objects_useraccrole(self):
+        """Test delete useraccrole."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccARGUMENT, AccAuthorization, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        UserAccROLE.delete(
+            UserAccROLE.id_user == self.useraccrole.id_user,
+            UserAccROLE.id_accROLE == self.useraccrole.id_accROLE)
+
+        # assure that role, action, authorization, argument, user
+        # still exists
+        self.assertTrue(
+            db.session.query(
+                AccROLE.query.filter(
+                    AccROLE.id == self.role.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccACTION.query.filter(
+                    AccACTION.id == self.action.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccAuthorization.query.filter(
+                    AccAuthorization.id == self.authorization.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccARGUMENT.query.filter(
+                    AccARGUMENT.id == self.argument.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                User.query.filter(
+                    User.id == self.user.id
+                ).exists()).scalar())
+
+    def test_delete_objects_user(self):
+        """Test delete user."""
+        from invenio_ext.sqlalchemy import db
+        from invenio_access.models import AccACTION, \
+            AccARGUMENT, AccAuthorization, AccROLE, UserAccROLE
+        from invenio_accounts.models import User
+
+        db.session.delete(User.query.filter(User.id == self.user.id).first())
+        db.session.commit()
+
+        # assure that role, action, authorization, argument, useraccrole
+        # still exists
+        self.assertTrue(
+            db.session.query(
+                AccROLE.query.filter(
+                    AccROLE.id == self.role.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccACTION.query.filter(
+                    AccACTION.id == self.action.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccAuthorization.query.filter(
+                    AccAuthorization.id == self.authorization.id
+                ).exists()).scalar())
+        self.assertTrue(
+            db.session.query(
+                AccARGUMENT.query.filter(
+                    AccARGUMENT.id == self.argument.id
+                ).exists()).scalar())
+
+        # assure that useraccrole is deleted
+        self.assertFalse(
+            db.session.query(
+                UserAccROLE.query.filter(
+                    UserAccROLE.id_user == self.useraccrole.id_user,
+                    UserAccROLE.id_accROLE == self.useraccrole.id_accROLE,
+                ).exists()).scalar())


### PR DESCRIPTION
* Improves access models with delete, update, count, exists, factory
  functions, smart getter and setter and cascade actions.
  (addresses inveniosoftware/invenio#3299)
  (closes inveniosoftware/invenio#3328)

* Deprecates most of the raw sql. (addresses #3098)

* Adds a testsuite for the models.

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>