### PR TITLE
global: entrypoint_name parameter renaming

### DIFF
--- a/invenio_access/ext.py
+++ b/invenio_access/ext.py
@@ -41,15 +41,16 @@ class InvenioAccess(object):
         if app:
             self.init_app(app, **kwargs)
 
-    def init_app(self, app, entrypoint_name='invenio_access.actions',
+    def init_app(self, app, entry_point_group='invenio_access.actions',
                  **kwargs):
         """Flask application initialization."""
         self.kwargs.update(kwargs)
         app.cli.add_command(access_cli, 'access')
         app.extensions['invenio-access'] = self
 
-        if entrypoint_name:
-            for base_entry in pkg_resources.iter_entry_points(entrypoint_name):
+        if entry_point_group:
+            for base_entry in pkg_resources.iter_entry_points(
+                    entry_point_group):
                 self.register_action(base_entry.load())
 
     def register_action(self, action):

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
     'isort>=4.2.2',
+    'mock>=1.0.0',
     'pep257>=0.7.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',


### PR DESCRIPTION
* Renames entrypoint_name parameter to entry_point_group to follow
  conventions in other modules.

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>