### PR TITLE
cache: DynamicPermission performance improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ cache:
 services:
   - mysql
   - postgresql
+  - redis-server
 
 env:
   - REQUIREMENTS=lowest EXTRAS=all SQLALCHEMY_DATABASE_URI="sqlite:///test.db"

--- a/invenio_access/__init__.py
+++ b/invenio_access/__init__.py
@@ -77,6 +77,11 @@ Dynamic permissions represent needs associated with ``ActionNeed`` or
 `'action'`. This consequently means that if the action is not attached to
 any user or role then it is **allowed** by default.
 
+The permissions are loaded from the database the first time you perform
+```needs``` or ```excludes``` in the DynamicPermission object and they are
+stored in the instance of DynamicPermission affected to be used in future
+calls.
+
 Action Needs
 ~~~~~~~~~~~~
 

--- a/invenio_access/ext.py
+++ b/invenio_access/ext.py
@@ -42,10 +42,11 @@ current_access = LocalProxy(
 class _AccessState(object):
     """Access state storing registered actions."""
 
-    def __init__(self, app, entry_point_group=None):
+    def __init__(self, app, entry_point_group=None, cache=None):
         """Initialize state."""
         self.app = app
         self.actions = {}
+        self.cache = cache
         if entry_point_group:
             self.load_entry_point_group(entry_point_group)
 
@@ -72,7 +73,8 @@ class InvenioAccess(object):
                  **kwargs):
         """Flask application initialization."""
         app.cli.add_command(access_cli, 'access')
-        state = _AccessState(app, entry_point_group=entry_point_group)
+        state = _AccessState(app, entry_point_group=entry_point_group,
+                             cache=kwargs.get('cache'))
         app.extensions['invenio-access'] = state
         return state
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'Werkzeug>=0.11.2',
+    'redis>=2.10.3'
 ]
 
 extras_require = {

--- a/tests/test_invenio_access_permissions.py
+++ b/tests/test_invenio_access_permissions.py
@@ -29,10 +29,11 @@ from __future__ import absolute_import, print_function
 
 from flask_principal import ActionNeed, RoleNeed, UserNeed
 from invenio_accounts.models import Role, User
+from invenio_db import db
 
+from invenio_access import InvenioAccess
 from invenio_access.models import ActionRoles, ActionUsers
 from invenio_access.permissions import DynamicPermission
-from invenio_db import db
 
 
 class FakeIdentity(object):
@@ -43,6 +44,7 @@ class FakeIdentity(object):
 
 def test_invenio_access_permissions_deny(app):
     """User without any provides can't access to a place limited to user 0"""
+    InvenioAccess(app)
     with app.test_request_context():
         permission = DynamicPermission(UserNeed(0))
 
@@ -52,6 +54,7 @@ def test_invenio_access_permissions_deny(app):
 
 def test_invenio_access_permission_for_users(app):
     """User can access to an action allowed/denied to the user"""
+    InvenioAccess(app)
     with app.test_request_context():
         db.session.begin(nested=True)
         user_can_all = User(email='all@invenio-software.org')
@@ -88,7 +91,8 @@ def test_invenio_access_permission_for_users(app):
 
 def test_invenio_access_permission_for_roles(app):
     """User with a role can access to an action allowed to the role"""
-    with app.app_context():
+    InvenioAccess(app)
+    with app.test_request_context():
         admin_role = Role(name='admin')
         reader_role = Role(name='reader')
         opener_role = Role(name='opener')

--- a/tests/test_invenio_access_permissions_cache.py
+++ b/tests/test_invenio_access_permissions_cache.py
@@ -1,0 +1,604 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""Module tests."""
+
+from __future__ import absolute_import, print_function
+
+import time
+
+from flask_principal import ActionNeed, Need, RoleNeed, UserNeed
+from invenio_accounts.models import Role, User
+from invenio_db import db
+from werkzeug.contrib.cache import RedisCache, SimpleCache
+
+from invenio_access import InvenioAccess
+from invenio_access.models import ActionRoles, ActionUsers
+from invenio_access.permissions import DynamicPermission
+
+
+class FakeIdentity(object):
+    """Fake class to test DynamicPermission."""
+    def __init__(self, *provides):
+        self.provides = provides
+
+
+def test_invenio_access_permission_cache(app):
+    """Caching the user using memory caching."""
+    cache = SimpleCache()
+    InvenioAccess(app, cache=cache)
+    with app.test_request_context():
+        user_can_all = User(email='all@invenio-software.org')
+        user_can_open = User(email='open@invenio-software.org')
+
+        db.session.add(user_can_all)
+        db.session.add(user_can_open)
+
+        db.session.add(ActionUsers(action='open', user=user_can_all))
+
+        db.session.flush()
+
+        permission_open = DynamicPermission(ActionNeed('open'))
+
+        identity_open = FakeIdentity(UserNeed(user_can_open.id))
+
+        assert not permission_open.allows(identity_open)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1)]),
+            True: set([])
+        }
+
+        db.session.add(ActionUsers(action='open', user=user_can_open))
+        db.session.flush()
+
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_open)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+
+
+def test_invenio_access_permission_cache_redis(app):
+    """Caching the user using redis."""
+    cache = RedisCache()
+    InvenioAccess(app, cache=cache)
+    with app.test_request_context():
+        user_can_all = User(email='all@invenio-software.org')
+        user_can_open = User(email='open@invenio-software.org')
+
+        db.session.add(user_can_all)
+        db.session.add(user_can_open)
+
+        db.session.add(ActionUsers(action='open', user=user_can_all))
+
+        db.session.flush()
+
+        identity_open = FakeIdentity(UserNeed(user_can_open.id))
+
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert not permission_open.allows(identity_open)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1)]),
+            True: set([])
+        }
+
+        db.session.add(ActionUsers(action='open', user=user_can_open))
+        db.session.flush()
+
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_open)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+
+
+def test_intenio_access_cache_performance(app):
+    """Performance test simulating 1000 users."""
+    InvenioAccess(app, cache=None)
+    with app.test_request_context():
+        # CDS has (2015-11-19) 74 actions with 414 possible arguments with
+        # 49259 users and 307 roles. In this test we are going to divide
+        # into 50 and use the next prime number.
+        users_number = 991
+        actions_users_number = 11
+        actions_roles_number = 7
+
+        roles = []
+        actions = []
+        for i in range(actions_roles_number):
+            role = Role(name='role{0}'.format(i))
+            roles.append(role)
+            db.session.add(role)
+            db.session.flush()
+
+            action_role = ActionRoles(
+                action='action{0}'.format(
+                    str(i % actions_roles_number)),
+                role=role)
+            actions.append(action_role)
+            db.session.add(action_role)
+            db.session.flush()
+
+        users = []
+        for i in range(users_number):
+            user = User(
+                email='invenio{0}@invenio-software.org'.format(str(i)),
+                roles=[roles[i % actions_roles_number]])
+            users.append(user)
+            db.session.add(user)
+            db.session.flush()
+
+            action_user = ActionUsers(action='action{0}'.format(
+                str((i % actions_users_number) + actions_roles_number)),
+                user=user)
+            actions.append(action_user)
+            db.session.add(action_user)
+            db.session.flush()
+
+        def test_permissions():
+            """Iterates over all users checking its permissions."""
+            for i in range(users_number):
+                identity = FakeIdentity(UserNeed(users[i].id))
+
+                # Allowed permission
+                permission_allowed_both = DynamicPermission(
+                    ActionNeed('action{0}'.format(
+                        (i % actions_users_number) +
+                        actions_roles_number)),
+                    ActionNeed('action{0}'.format(i % actions_roles_number))
+                )
+                assert permission_allowed_both.allows(identity)
+
+                # Not allowed action user
+                permission_not_allowed_user = DynamicPermission(
+                    ActionNeed('action{0}'.format(
+                        (i + 1) % actions_users_number +
+                        actions_roles_number))
+                )
+                assert not permission_not_allowed_user.allows(identity)
+
+                # Not allowed action role
+                permission_not_allowed_role = DynamicPermission(
+                    ActionNeed('action{0}'.format(
+                        (i + 1) % actions_roles_number))
+                )
+                assert not permission_not_allowed_role.allows(identity)
+
+        app.extensions['invenio-access'].cache = None
+        start_time_wo_cache = time.time()
+        test_permissions()
+        end_time_wo_cache = time.time()
+        time_wo_cache = end_time_wo_cache - start_time_wo_cache
+
+        app.extensions['invenio-access'].cache = SimpleCache()
+        start_time_w_cache = time.time()
+        test_permissions()
+        end_time_w_cache = time.time()
+        time_w_cache = end_time_w_cache - start_time_w_cache
+
+        assert time_wo_cache / time_w_cache > 10
+
+
+def test_invenio_access_permission_cache_users_updates(app):
+    """Testing ActionUsers cache with inserts/updates/deletes."""
+    cache = SimpleCache()
+    InvenioAccess(app, cache=cache)
+    with app.test_request_context():
+        # Creation of some data to test.
+        user_1 = User(email='user_1@invenio-software.org')
+        user_2 = User(email='user_2@invenio-software.org')
+        user_3 = User(email='user_3@invenio-software.org')
+        user_4 = User(email='user_4@invenio-software.org')
+        user_5 = User(email='user_5@invenio-software.org')
+
+        db.session.add(user_1)
+        db.session.add(user_2)
+        db.session.add(user_3)
+        db.session.add(user_4)
+        db.session.add(user_5)
+
+        db.session.add(ActionUsers(action='open', user=user_1))
+        db.session.add(ActionUsers(action='write', user=user_4))
+
+        db.session.flush()
+
+        # Creation identities to test.
+        identity_user_1 = FakeIdentity(UserNeed(user_1.id))
+        identity_user_2 = FakeIdentity(UserNeed(user_2.id))
+        identity_user_3 = FakeIdentity(UserNeed(user_3.id))
+        identity_user_4 = FakeIdentity(UserNeed(user_4.id))
+        identity_user_5 = FakeIdentity(UserNeed(user_5.id))
+
+        # Test if user 1 can open. In this case, the cache should store only
+        # this object.
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_user_1)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1)]),
+            True: set([])
+        }
+
+        # Test if user 4 can write. In this case, the cache should have this
+        # new object and the previous one (Open is allowed to user_1)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_4)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=4)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1)]),
+            True: set([])
+        }
+
+        # If we add a new user to the action open, the open action in cache
+        # should be removed but it should still containing the write entry.
+        db.session.add(ActionUsers(action='open', user=user_2))
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.open")
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_user_2)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=4)]),
+            True: set([])
+        }
+
+        # Test if the new user is added to the action 'open'
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_4)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=4)]),
+            True: set([])
+        }
+
+        # If we update an action swapping a user, the cache containing the
+        # action, should be removed.
+        user_4_action_write = ActionUsers.query.filter(
+            ActionUsers.action == 'write' and
+            ActionUsers.user == user_4).first()
+        user_4_action_write.user = user_3
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        assert cache.has("DynamicPermission.action.open")
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+
+        # Test if the user_3 can now write.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_user_4)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=3)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+
+        # If we remove a user from an action, the cache should clear the
+        # action item.
+        user_3_action_write = ActionUsers.query.filter(
+            ActionUsers.action == 'write' and
+            ActionUsers.user == user_3).first()
+        db.session.delete(user_3_action_write)
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        # If no one is allowed to perform an action then everybody is allowed.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([]),
+            True: set([])
+        }
+        db.session.add(ActionUsers(action='write', user=user_5))
+        db.session.flush()
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_5)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_user_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=5)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+
+        # If you update the name of an existing action, the previous action
+        # and the new action should be remove from cache.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_user_5)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=5)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2)]),
+            True: set([])
+        }
+        user_5_action_write = ActionUsers.query.filter(
+            ActionUsers.action == 'write' and
+            ActionUsers.user == user_5).first()
+        user_5_action_write.action = 'open'
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        assert not cache.has("DynamicPermission.action.open")
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_user_1)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='id', value=1),
+                        Need(method='id', value=2),
+                        Need(method='id', value=5)]),
+            True: set([])
+        }
+        db.session.add(ActionUsers(action='write', user=user_4))
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_user_5)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='id', value=4)]),
+            True: set([])
+        }
+
+
+def test_invenio_access_permission_cache_roles_updates(app):
+    """Testing ActionRoles cache with inserts/updates/deletes."""
+    # This test case is doing the same of user test case but using roles.
+    cache = SimpleCache()
+    InvenioAccess(app, cache=cache)
+    with app.test_request_context():
+        # Creation of some data to test.
+        role_1 = Role(name='role_1')
+        role_2 = Role(name='role_2')
+        role_3 = Role(name='role_3')
+        role_4 = Role(name='role_4')
+        role_5 = Role(name='role_5')
+
+        db.session.add(role_1)
+        db.session.add(role_2)
+        db.session.add(role_3)
+        db.session.add(role_4)
+        db.session.add(role_5)
+
+        db.session.add(ActionRoles(action='open', role=role_1))
+        db.session.add(ActionRoles(action='write', role=role_4))
+
+        db.session.flush()
+
+        # Creation of identities to test.
+        identity_fake_role_1 = FakeIdentity(RoleNeed(role_1.name))
+        identity_fake_role_2 = FakeIdentity(RoleNeed(role_2.name))
+        identity_fake_role_3 = FakeIdentity(RoleNeed(role_3.name))
+        identity_fake_role_4 = FakeIdentity(RoleNeed(role_4.name))
+        identity_fake_role_5 = FakeIdentity(RoleNeed(role_5.name))
+
+        # Test if role 1 can open. In this case, the cache should store only
+        # this object.
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_fake_role_1)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name)]),
+            True: set([])
+        }
+
+        # Test if role 4 can write. In this case, the cache should have this
+        # new object and the previous one (Open is allowed to role_1)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_4)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_4.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name)]),
+            True: set([])
+        }
+
+        # If we add a new role to the action open, the open action in cache
+        # should be removed but it should still containing the write entry.
+        db.session.add(ActionRoles(action='open', role=role_2))
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.open")
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_fake_role_2)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_4.name)]),
+            True: set([])
+        }
+
+        # Test if the new role is added to the action 'open'
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_4)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_4.name)]),
+            True: set([])
+        }
+
+        # If we update an action swapping a role, the cache containing the
+        # action, should be removed.
+        role_4_action_write = ActionRoles.query.filter(
+            ActionRoles.action == 'write' and
+            ActionRoles.role == role_4).first()
+        role_4_action_write.role = role_3
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        assert cache.has("DynamicPermission.action.open")
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+
+        # Test if the role_3 can write now.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_fake_role_4)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_3.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+
+        # If we remove a role from an action, the cache should clear the
+        # action item.
+        role_3_action_write = ActionRoles.query.filter(
+            ActionRoles.action == 'write' and
+            ActionRoles.role == role_3).first()
+        db.session.delete(role_3_action_write)
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        # If no one is allowed to perform an action then everybody is allowed.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([]),
+            True: set([])
+        }
+        db.session.add(ActionRoles(action='write', role=role_5))
+        db.session.flush()
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_5)
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_fake_role_3)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_5.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+
+        # If you update the name of an existing action, the previous action
+        # and the new action should be remove from cache.
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert permission_write.allows(identity_fake_role_5)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_5.name)]),
+            True: set([])
+        }
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name)]),
+            True: set([])
+        }
+        role_5_action_write = ActionRoles.query.filter(
+            ActionRoles.action == 'write' and
+            ActionRoles.role == role_5).first()
+        role_5_action_write.action = 'open'
+        db.session.flush()
+        assert not cache.has("DynamicPermission.action.write")
+        assert not cache.has("DynamicPermission.action.open")
+        permission_open = DynamicPermission(ActionNeed('open'))
+        assert permission_open.allows(identity_fake_role_1)
+        assert cache.get(
+            "DynamicPermission.action.open") == {
+            False: set([Need(method='role', value=role_1.name),
+                        Need(method='role', value=role_2.name),
+                        Need(method='role', value=role_5.name)]),
+            True: set([])
+        }
+        db.session.add(ActionRoles(action='write', role=role_4))
+        permission_write = DynamicPermission(ActionNeed('write'))
+        assert not permission_write.allows(identity_fake_role_5)
+        assert cache.get(
+            "DynamicPermission.action.write") == {
+            False: set([Need(method='role', value=role_4.name)]),
+            True: set([])
+        }


### PR DESCRIPTION
* Improves the speed of DynamicPermission. The permissions are now
  cached in order to reduce the timing of future requests. The cache
  is cleared each time that the tables ActionRoles or ActionUsers are
  modified. (closes #30)

Signed-off-by: Javier Delgado <javier.delgado.fernandez@cern.ch>