### PR TITLE
permissions: not working on not logged users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
+#FIXME see https://github.com/inveniosoftware/invenio-access/issues/129
+dist: precise
 
 notifications:
   email: false
@@ -62,7 +64,7 @@ before_install:
   - "requirements-builder --level=min setup.py > .travis-lowest-requirements.txt"
   - "requirements-builder --level=pypi setup.py > .travis-release-requirements.txt"
   - "requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
-  - "mysql -e 'CREATE DATABASE IF NOT EXISTS travis;' -uroot"
+  - "mysql -e 'CREATE DATABASE IF NOT EXISTS travis; GRANT ALL ON travis.* TO 'travis';' -uroot"
   - "psql -c 'CREATE DATABASE travis;' -U postgres"
 
 install:

--- a/invenio_access/alembic/dbe499bfda43_prevent_null_in_actionusers_for_.py
+++ b/invenio_access/alembic/dbe499bfda43_prevent_null_in_actionusers_for_.py
@@ -1,0 +1,42 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Prevent NULL in ActionUsers for stability reasons."""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'dbe499bfda43'
+down_revision = '2069a982633b'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column('access_actionsusers', 'user_id', nullable=False)
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column('access_actionsusers', 'user_id', nullable=True)

--- a/invenio_access/cli.py
+++ b/invenio_access/cli.py
@@ -119,14 +119,6 @@ def allow_action(action, argument):
     """Allow action."""
 
 
-@allow_action.command('any')
-def allow_any():
-    """Allow any user."""
-    def processor(action, argument):
-        db.session.add(ActionUsers.allow(action, argument=argument))
-    return processor
-
-
 @allow_action.command('user')
 @argument_user
 def allow_user(user):
@@ -166,14 +158,6 @@ def process_allow_action(processors, action, argument):
 @option_argument
 def deny_action(action, argument):
     """Deny actions."""
-
-
-@deny_action.command('all')
-def deny_any():
-    """Deny all users."""
-    def processor(action, argument):
-        db.session.add(ActionUsers.deny(action, argument=argument))
-    return processor
 
 
 @deny_action.command('user')

--- a/invenio_access/models.py
+++ b/invenio_access/models.py
@@ -122,7 +122,7 @@ class ActionNeedMixin(object):
 
 
 class ActionUsers(ActionNeedMixin, db.Model):
-    """ActionRoles data model.
+    """ActionUsers data model.
 
     It relates an allowed action with a user.
     """
@@ -136,7 +136,7 @@ class ActionUsers(ActionNeedMixin, db.Model):
 
     user_id = db.Column(db.Integer(),
                         db.ForeignKey(User.id, ondelete='CASCADE'),
-                        nullable=True, index=True)
+                        nullable=False, index=True)
 
     user = db.relationship("User",
                            backref=db.backref("actionusers",

--- a/invenio_access/permissions.py
+++ b/invenio_access/permissions.py
@@ -72,7 +72,7 @@ class DynamicPermission(Permission):
 
         If ``ActionNeed`` or ``ParameterizedActionNeed`` is not allowed or
         restricted to any user or role then it is **ALLOWED** to anybody.
-        This is a major diference to standard ``Permission`` class.
+        This is a major difference to standard ``Permission`` class.
     """
 
     def __init__(self, *needs):

--- a/tests/test_invenio_access_cli.py
+++ b/tests/test_invenio_access_cli.py
@@ -92,15 +92,7 @@ def test_any_all_global(script_info):
     """Test any/all/global subcommands."""
     runner = CliRunner()
 
-    result = runner.invoke(access, ['allow', 'open', 'any'],
-                           obj=script_info)
-    assert result.exit_code == 0
-
     result = runner.invoke(access, ['remove', 'open', 'global'],
-                           obj=script_info)
-    assert result.exit_code == 0
-
-    result = runner.invoke(access, ['deny', 'open', 'all'],
                            obj=script_info)
     assert result.exit_code == 0
 


### PR DESCRIPTION
I've added several tests for invenio-access, particularly for actions with arguments, and for not logged users.

Globally, we should have the following:
## parameterized actions

Imagine you have 2 users: `user1` and `user2`, and 2 actions: `action1` and `action2`.
You have the following actions users table:

| id | user | action | parameter |
| --- | --- | --- | --- |
| 1 |  | action1 |  |
| 2 | user1 | action1 | p1 |
| 3 | user1 | action2 |  |
| 4 | user2 | action2 | p1 |
1. The `action1` and all its children (action1 with any parameters) will be accessible by anybody because of the first rule.
2. The second rule says that only `user1` can access to the `action1`, but it is useless because of the rule 1.
3. The third rule says that only `user1` can access to `action2`.
4. Finally, the last rule says that `user2` can access to `action2` with `p1` parameter.

To summarize, `user1` can access everything.
`user2` can only `action1` and `action1` with any parameters. He can also access to `action2` but only with parameter `p1`
Finally, a not-logged user will be able to access `action1`, but that's all.

The problem I actually have is the _overriden_ rules explained in rules 1 and 2. Actually the test fails at line 131 (the only assert that fails), while this should pass.

See the comments for more details.
