### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-Access.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-access
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/adminapp.py
+++ b/examples/adminapp.py
@@ -38,10 +38,10 @@ Create some users:
 
 .. code-block:: console
 
-   $ flask users create info@invenio-software.org -a
-   $ flask users create reader@invenio-software.org -a
-   $ flask users create editor@invenio-software.org -a
-   $ flask users create admin@invenio-software.org -a
+   $ flask users create info@inveniosoftware.org -a
+   $ flask users create reader@inveniosoftware.org -a
+   $ flask users create editor@inveniosoftware.org -a
+   $ flask users create admin@inveniosoftware.org -a
 
 Run the development server:
 

--- a/examples/app.py
+++ b/examples/app.py
@@ -38,26 +38,26 @@ Create some users:
 
 .. code-block:: console
 
-   $ flask users create info@invenio-software.org -a
-   $ flask users create reader@invenio-software.org -a
-   $ flask users create editor@invenio-software.org -a
-   $ flask users create admin@invenio-software.org -a
+   $ flask users create info@inveniosoftware.org -a
+   $ flask users create reader@inveniosoftware.org -a
+   $ flask users create editor@inveniosoftware.org -a
+   $ flask users create admin@inveniosoftware.org -a
 
 Add a role to a user:
 
 .. code-block:: console
 
    $ flask roles create -n admin
-   $ flask roles add -u info@invenio-software.org -r admin
-   $ flask roles add -u admin@invenio-software.org -r admin
+   $ flask roles add -u info@inveniosoftware.org -r admin
+   $ flask roles add -u admin@inveniosoftware.org -r admin
 
 Assign some allowed actions to this users:
 
 .. code-block:: console
 
-   $ flask access allow open -e editor@invenio-software.org
-   $ flask access deny open -e info@invenio-software.org
-   $ flask access allow read -e reader@invenio-software.org
+   $ flask access allow open -e editor@inveniosoftware.org
+   $ flask access deny open -e info@inveniosoftware.org
+   $ flask access allow read -e reader@inveniosoftware.org
    $ flask access allow open -r admin
    $ flask access allow read -r admin
 

--- a/invenio_access/__init__.py
+++ b/invenio_access/__init__.py
@@ -118,8 +118,8 @@ some users and roles in your database.
 
 >>> from invenio_db import db
 >>> from invenio_accounts.models import User, Role
->>> admin = User(email='admin@invenio-software.org')
->>> student = User(email='student@invenio-software.org')
+>>> admin = User(email='admin@inveniosoftware.org')
+>>> student = User(email='student@inveniosoftware.org')
 >>> db.session.begin(nested=True)
 <sqlalchemy.orm.session.SessionTransaction object ...
 >>> db.session.add(admin)

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ directory = invenio_access/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_access/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     keywords='invenio access',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-access',
     packages=packages,
     zip_safe=False,

--- a/tests/test_invenio_access_cli.py
+++ b/tests/test_invenio_access_cli.py
@@ -121,11 +121,11 @@ def test_access_matrix(script_info_cli_list):
     runner = CliRunner()
 
     user_roles = {
-        'admin@invenio-software.org': ['admin'],
-        'admin-edit@invenio-software.org': ['admin'],
-        'open@invenio-software.org': ['opener'],
-        'edit@invenio-software.org': ['editor'],
-        'info@invenio-software.org': ['opener'],
+        'admin@inveniosoftware.org': ['admin'],
+        'admin-edit@inveniosoftware.org': ['admin'],
+        'open@inveniosoftware.org': ['opener'],
+        'edit@inveniosoftware.org': ['editor'],
+        'info@inveniosoftware.org': ['opener'],
     }
 
     action_roles = {
@@ -172,14 +172,14 @@ def test_access_matrix(script_info_cli_list):
 
     result = runner.invoke(
         access,
-        ['deny', 'edit', '-e', 'admin-edit@invenio-software.org'],
+        ['deny', 'edit', '-e', 'admin-edit@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0
 
     result = runner.invoke(
         access,
-        ['allow', 'edit', '-a', '1', '-e', 'info@invenio-software.org'],
+        ['allow', 'edit', '-a', '1', '-e', 'info@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0
@@ -191,7 +191,7 @@ def test_access_matrix(script_info_cli_list):
     permission_edit_2 = DynamicPermission(ParameterizedActionNeed('edit', 2))
 
     user_permissions = {
-        'admin@invenio-software.org': {
+        'admin@inveniosoftware.org': {
             True: [
                 permission_open,
                 permission_edit,
@@ -199,7 +199,7 @@ def test_access_matrix(script_info_cli_list):
                 permission_edit_2,
             ],
         },
-        'admin-edit@invenio-software.org': {
+        'admin-edit@inveniosoftware.org': {
             True: [permission_open],
             False: [
                 permission_edit,
@@ -207,7 +207,7 @@ def test_access_matrix(script_info_cli_list):
                 permission_edit_2,
             ],
         },
-        'open@invenio-software.org': {
+        'open@inveniosoftware.org': {
             True: [permission_open],
             False: [
                 permission_edit,
@@ -215,7 +215,7 @@ def test_access_matrix(script_info_cli_list):
                 permission_edit_2,
             ],
         },
-        'edit@invenio-software.org': {
+        'edit@inveniosoftware.org': {
             True: [
                 permission_edit,
                 permission_edit_1,
@@ -223,7 +223,7 @@ def test_access_matrix(script_info_cli_list):
             ],
             False: [permission_open],
         },
-        'info@invenio-software.org': {
+        'info@inveniosoftware.org': {
             True: [
                 permission_open,
                 permission_edit_1,
@@ -254,11 +254,11 @@ def test_access_matrix(script_info_cli_list):
 
     result = runner.invoke(
         access,
-        ['show', '-e', 'admin-edit@invenio-software.org'],
+        ['show', '-e', 'admin-edit@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0
-    assert 'user:admin-edit@invenio-software.org:edit::deny' in result.output
+    assert 'user:admin-edit@inveniosoftware.org:edit::deny' in result.output
 
     result = runner.invoke(
         access,
@@ -282,14 +282,14 @@ def test_access_matrix(script_info_cli_list):
 
     result = runner.invoke(
         access,
-        ['remove', 'edit', '-e', 'admin-edit@invenio-software.org'],
+        ['remove', 'edit', '-e', 'admin-edit@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0
 
     result = runner.invoke(
         access,
-        ['remove', 'edit', '-a', '1', '-e', 'info@invenio-software.org'],
+        ['remove', 'edit', '-a', '1', '-e', 'info@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0
@@ -297,7 +297,7 @@ def test_access_matrix(script_info_cli_list):
     # All authorizations should be removed.
     result = runner.invoke(
         access,
-        ['show', '-r', 'admin-edit@invenio-software.org'],
+        ['show', '-r', 'admin-edit@inveniosoftware.org'],
         obj=script_info
     )
     assert result.exit_code == 0

--- a/tests/test_invenio_access_permissions.py
+++ b/tests/test_invenio_access_permissions.py
@@ -58,10 +58,10 @@ def test_invenio_access_permission_for_users(app):
     InvenioAccess(app)
     with app.test_request_context():
         db.session.begin(nested=True)
-        superuser = User(email='superuser@invenio-software.org')
-        user_can_all = User(email='all@invenio-software.org')
-        user_can_read = User(email='read@invenio-software.org')
-        user_can_open = User(email='open@invenio-software.org')
+        superuser = User(email='superuser@inveniosoftware.org')
+        user_can_all = User(email='all@inveniosoftware.org')
+        user_can_read = User(email='read@inveniosoftware.org')
+        user_can_open = User(email='open@inveniosoftware.org')
 
         db.session.add(superuser)
         db.session.add(user_can_all)

--- a/tests/test_invenio_access_permissions_cache.py
+++ b/tests/test_invenio_access_permissions_cache.py
@@ -51,8 +51,8 @@ def test_invenio_access_permission_cache(app):
     cache = SimpleCache()
     InvenioAccess(app, cache=cache)
     with app.test_request_context():
-        user_can_all = User(email='all@invenio-software.org')
-        user_can_open = User(email='open@invenio-software.org')
+        user_can_all = User(email='all@inveniosoftware.org')
+        user_can_open = User(email='open@inveniosoftware.org')
 
         db.session.add(user_can_all)
         db.session.add(user_can_open)
@@ -88,8 +88,8 @@ def test_invenio_access_permission_cache_redis(app):
     cache = RedisCache()
     InvenioAccess(app, cache=cache)
     with app.test_request_context():
-        user_can_all = User(email='all@invenio-software.org')
-        user_can_open = User(email='open@invenio-software.org')
+        user_can_all = User(email='all@inveniosoftware.org')
+        user_can_open = User(email='open@inveniosoftware.org')
 
         db.session.add(user_can_all)
         db.session.add(user_can_open)
@@ -149,7 +149,7 @@ def test_intenio_access_cache_performance(app):
         users = []
         for i in range(users_number):
             user = User(
-                email='invenio{0}@invenio-software.org'.format(str(i)),
+                email='invenio{0}@inveniosoftware.org'.format(str(i)),
                 roles=[roles[i % actions_roles_number]])
             users.append(user)
             db.session.add(user)
@@ -212,11 +212,11 @@ def test_invenio_access_permission_cache_users_updates(app):
     InvenioAccess(app, cache=cache)
     with app.test_request_context():
         # Creation of some data to test.
-        user_1 = User(email='user_1@invenio-software.org')
-        user_2 = User(email='user_2@invenio-software.org')
-        user_3 = User(email='user_3@invenio-software.org')
-        user_4 = User(email='user_4@invenio-software.org')
-        user_5 = User(email='user_5@invenio-software.org')
+        user_1 = User(email='user_1@inveniosoftware.org')
+        user_2 = User(email='user_2@inveniosoftware.org')
+        user_3 = User(email='user_3@inveniosoftware.org')
+        user_4 = User(email='user_4@inveniosoftware.org')
+        user_5 = User(email='user_5@inveniosoftware.org')
 
         db.session.add(user_1)
         db.session.add(user_2)


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>