### PR TITLE
examples: make teardown.sh osx compatible

### DIFF
--- a/examples/app-teardown.sh
+++ b/examples/app-teardown.sh
@@ -9,4 +9,4 @@ export FLASK_APP=app.py
 flask db drop --yes-i-know
 
 # clean environment
-[ -e "$DIR/instance" ] && rm $DIR/instance -Rf
+[ -e "$DIR/instance" ] && rm -Rf $DIR/instance


### PR DESCRIPTION
* FIX Makes `rm` call osx compatible. (closes #104)

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>