### PR TITLE
release: v1.0.0a12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,6 @@
 ..
     This file is part of Invenio.
-    Copyright (C) 2015, 2016 CERN.
+    Copyright (C) 2015, 2016, 2017 CERN.
 
     Invenio is free software; you can redistribute it
     and/or modify it under the terms of the GNU General Public License as
@@ -24,7 +24,7 @@
 Changes
 =======
 
-Version 1.0.0a11 (released 2016-11-11)
+Version 1.0.0a12 (released 2017-05-05)
 --------------------------------------
 
 - Major incompatible rewrite.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==========================
- Invenio-Access v1.0.0a11
+ Invenio-Access v1.0.0a12
 ==========================
 
-Invenio-Access v1.0.0a11 was released on November 11, 2016.
+Invenio-Access v1.0.0a12 was released on May 05, 2017.
 
 About
 -----
@@ -14,7 +14,7 @@ Invenio module for common role based access control.
 Installation
 ------------
 
-   $ pip install invenio-access==1.0.0a11
+   $ pip install invenio-access==1.0.0a12
 
 Documentation
 -------------

--- a/invenio_access/version.py
+++ b/invenio_access/version.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a12.dev20161111"
+__version__ = "1.0.0a12"

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,3 +51,6 @@ output-dir = invenio_access/translations/
 [update_catalog]
 input-file = invenio_access/translations/messages.pot
 output-dir = invenio_access/translations/
+
+[pydocstyle]
+add_ignore = D401


### PR DESCRIPTION
This release is needed in order to release invenio-db without breaking invenio-app-ils (see 41c6325bce9a484523b4ac780f28790d001c62b2).

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>