### PR TITLE
docs: example app fix

### DIFF
--- a/docs/examplesapp.rst
+++ b/docs/examplesapp.rst
@@ -24,4 +24,6 @@
 Example application
 ===================
 
-.. automodule:: app
+.. include:: ../examples/app.py
+   :start-after: SPHINX-START
+   :end-before: SPHINX-END

--- a/examples/app.py
+++ b/examples/app.py
@@ -25,6 +25,8 @@
 
 """Minimal Flask application example for development.
 
+SPHINX-START
+
 Start redis server.
 
 Install requirements:
@@ -65,6 +67,8 @@ To be able to uninstall the example app:
     If you are using an action in your app which does not have any role or user
     assigned, the action will be allowed to perform by everyone (Anonymous
     users included)
+
+SPHINX-END
 """
 
 from __future__ import absolute_import, print_function


### PR DESCRIPTION
* FIXES rendering of the examples/app.py documentation
  (closes [125](https://github.com/inveniosoftware/invenio-access/issues/125))

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>