### PR TITLE
model: fix alembic recipes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 #FIXME see https://github.com/inveniosoftware/invenio-access/issues/129
-dist: precise
+dist: trusty
 
 notifications:
   email: false
@@ -45,14 +45,14 @@ services:
 
 env:
   - REQUIREMENTS=lowest EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=lowest EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/travis"
-  - REQUIREMENTS=lowest EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/travis"
+  - REQUIREMENTS=lowest EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://root@localhost:3306/invenio"
+  - REQUIREMENTS=lowest EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
   - REQUIREMENTS=release EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=release EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/travis"
-  - REQUIREMENTS=release EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/travis" DEPLOY=true
+  - REQUIREMENTS=release EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://root@localhost:3306/invenio"
+  - REQUIREMENTS=release EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio" DEPLOY=true
   - REQUIREMENTS=devel EXTRAS=all,sqlite SQLALCHEMY_DATABASE_URI="sqlite:///test.db"
-  - REQUIREMENTS=devel EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://travis@localhost:3306/travis"
-  - REQUIREMENTS=devel EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/travis"
+  - REQUIREMENTS=devel EXTRAS=all,mysql SQLALCHEMY_DATABASE_URI="mysql+pymysql://root@localhost:3306/invenio"
+  - REQUIREMENTS=devel EXTRAS=all,postgresql SQLALCHEMY_DATABASE_URI="postgresql+psycopg2://postgres@localhost:5432/invenio"
 
 python:
   - "2.7"
@@ -64,8 +64,8 @@ before_install:
   - "requirements-builder --level=min setup.py > .travis-lowest-requirements.txt"
   - "requirements-builder --level=pypi setup.py > .travis-release-requirements.txt"
   - "requirements-builder --level=dev --req requirements-devel.txt setup.py > .travis-devel-requirements.txt"
-  - "mysql -e 'CREATE DATABASE IF NOT EXISTS travis; GRANT ALL ON travis.* TO 'travis';' -uroot"
-  - "psql -c 'CREATE DATABASE travis;' -U postgres"
+  - "mysql -e 'CREATE DATABASE IF NOT EXISTS invenio; GRANT ALL ON invenio.* TO 'root';' -uroot"
+  - "psql -c 'CREATE DATABASE invenio;' -U postgres"
 
 install:
   - "travis_retry pip install -r .travis-${REQUIREMENTS}-requirements.txt"

--- a/invenio_access/__init__.py
+++ b/invenio_access/__init__.py
@@ -324,8 +324,8 @@ True
 
 System roles
 ------------
-Invenio-Access, in addition to roles defined by the administrator, provides also
-system roles. System roles are defined by the system and automatically
+Invenio-Access, in addition to roles defined by the administrator, provides
+also system roles. System roles are defined by the system and automatically
 assigned to users.
 
 By default the following system roles exists:

--- a/invenio_access/alembic/04480be1593e_add_actionsystemroles.py
+++ b/invenio_access/alembic/04480be1593e_add_actionsystemroles.py
@@ -30,7 +30,7 @@ from alembic import op
 revision = '04480be1593e'
 down_revision = 'dbe499bfda43'
 branch_labels = ()
-depends_on = '35c1075e6360'  # invenio-db "Force naming convention"
+depends_on = None
 
 
 def upgrade():

--- a/invenio_access/alembic/2069a982633b_add_on_delete_cascade_constraint.py
+++ b/invenio_access/alembic/2069a982633b_add_on_delete_cascade_constraint.py
@@ -29,7 +29,7 @@ from alembic import op
 revision = '2069a982633b'
 down_revision = '2f63be7b7572'
 branch_labels = ()
-depends_on = None
+depends_on = '35c1075e6360'  # invenio-db "Force naming convention"
 
 
 def upgrade():

--- a/invenio_access/alembic/dbe499bfda43_prevent_null_in_actionusers_for_.py
+++ b/invenio_access/alembic/dbe499bfda43_prevent_null_in_actionusers_for_.py
@@ -35,11 +35,33 @@ depends_on = None
 
 def upgrade():
     """Upgrade database."""
+    op.drop_constraint(u'fk_access_actionsusers_user_id_accounts_user',
+                       'access_actionsusers', type_='foreignkey')
+    op.drop_index(op.f('ix_access_actionsusers_user_id'),
+                  table_name='access_actionsusers')
+
     op.alter_column('access_actionsusers', 'user_id', nullable=False,
                     existing_type=sa.Integer())
+
+    op.create_index(op.f('ix_access_actionsusers_user_id'),
+                    'access_actionsusers', ['user_id'], unique=False)
+    op.create_foreign_key(op.f('fk_access_actionsusers_user_id_accounts_user'),
+                          'access_actionsusers', 'accounts_user', ['user_id'],
+                          ['id'], ondelete='CASCADE')
 
 
 def downgrade():
     """Downgrade database."""
+    op.drop_constraint(u'fk_access_actionsusers_user_id_accounts_user',
+                       'access_actionsusers', type_='foreignkey')
+    op.drop_index(op.f('ix_access_actionsusers_user_id'),
+                  table_name='access_actionsusers')
+
     op.alter_column('access_actionsusers', 'user_id', nullable=True,
                     existing_type=sa.Integer())
+
+    op.create_index(op.f('ix_access_actionsusers_user_id'),
+                    'access_actionsusers', ['user_id'], unique=False)
+    op.create_foreign_key(op.f('fk_access_actionsusers_user_id_accounts_user'),
+                          'access_actionsusers', 'accounts_user', ['user_id'],
+                          ['id'], ondelete='CASCADE')


### PR DESCRIPTION
* Fixes alembic recipe "preventing NULL in ActionUsers" because of
  a mysql bug. (closes #142)

* Fixes alembic recipes dependency so that the naming convention is
  executed at the right time.

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>