### PR TITLE
permissions: add system_identity and system_process role

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@
 Changes
 =======
 
+Version 1.4.2 (released 2021-02-16)
+
+- adds a new system role "system_process".
+- adds a new identity providing the system process role.
+
 Version 1.4.1 (released 2020-05-07)
 
 - set Sphinx ``<3`` because of errors related to application context

--- a/invenio_access/permissions.py
+++ b/invenio_access/permissions.py
@@ -12,7 +12,7 @@ from collections import namedtuple
 from functools import partial
 from itertools import chain
 
-from flask_principal import ActionNeed, Need
+from flask_principal import ActionNeed, Identity, Need
 from flask_principal import Permission as _Permission
 
 from .models import ActionRoles, ActionSystemRoles, ActionUsers, \
@@ -52,6 +52,25 @@ authenticated_user = SystemRoleNeed("authenticated_user")
 
 This role is used to assign all authenticated users to an action.
 """
+
+system_process = SystemRoleNeed("system_process")
+"""System role for processes initiated by Invenio itself."""
+
+#
+# Identities
+#
+
+# the primary requirement for the system user's ID is to be unique
+# the IDs of users provided by Invenio-Accounts are positive integers
+# the ID of an AnonymousIdentity from Flask-Principle is None
+# and the documentation for Flask-Principal makes use of strings for some IDs
+system_user_id = "system"
+"""The user ID of the system itself, used in its Identity."""
+
+system_identity = Identity(system_user_id)
+"""Identity used by system processes."""
+
+system_identity.provides.add(system_process)
 
 
 class _P(namedtuple("Permission", ["needs", "excludes"])):

--- a/invenio_access/version.py
+++ b/invenio_access/version.py
@@ -12,4 +12,4 @@ This file is imported by ``invenio_access.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/setup.py
+++ b/setup.py
@@ -89,6 +89,7 @@ setup(
             'any_user = invenio_access.permissions:any_user',
             'authenticated_user = '
             'invenio_access.permissions:authenticated_user',
+            'system_process = invenio_access.permissions:system_process',
         ],
         'invenio_admin.views': [
             'invenio_access_action_users = '


### PR DESCRIPTION
closes inveniosoftware/invenio-vocabularies#22

add a `system_identity` and the `system_process` role for service requests initiated by the system itself