### PR TITLE
permissions: improve default needs

### DIFF
--- a/invenio_access/permissions.py
+++ b/invenio_access/permissions.py
@@ -127,7 +127,8 @@ class Permission(_Permission):
         """
         self._permissions = None
         self.explicit_needs = set(needs)
-        self.explicit_needs.add(superuser_access)
+        if not self.allow_by_default:
+            self.explicit_needs.add(superuser_access)
         self.explicit_excludes = set()
 
     @staticmethod

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -435,7 +435,7 @@ def test_system_roles(access_app):
     assert permission_write.allows(superuser)
 
 
-def test_allow_by_default(access_app, dynamic_permission):
+def test_allow_by_default(access_app, dynamic_permission, monkeypatch):
     """Test that dynamic permissions allows access by default."""
     anonymous, superuser = create_users("anonymous", "superuser")
     act_access_backoffice = ActionNeed("access-backoffice")
@@ -449,3 +449,9 @@ def test_allow_by_default(access_app, dynamic_permission):
     superuser = get_superuser()
     assert permission.allows(superuser)
     assert dyn_permission.allows(superuser)
+
+    # Allow access if `allow_by_default` property is set to `True`.
+    monkeypatch.setattr(
+        'invenio_access.permissions.Permission.allow_by_default', True)
+    permission, = create_permissions({"needs": [act_access_backoffice]})
+    assert permission.allows(anonymous)


### PR DESCRIPTION
* Avoids to add a default need for superuser role if `allow_by_default` property is set to `True`.

Co-Authored-by: Sébastien Délèze <sebastien.deleze@rero.ch>