### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_access/ext.py
+++ b/invenio_access/ext.py
@@ -105,7 +105,14 @@ class _AccessState(object):
 
         :param entry_point_group: The entrypoint for extensions.
         """
-        for ep in entry_points(group=entry_point_group):
+        # NOTE
+        # the set call is a quick fix for python3.9. it is not
+        # necessary for python3.12 and can be removed after we drop
+        # python3.9 support.
+        # in python3.9 for tests the superuser-access entrypoint
+        # exists twice
+        eps = set(entry_points(group=entry_point_group))
+        for ep in eps:
             self.register_action(ep.load())
 
     def register_system_role(self, system_role):
@@ -124,7 +131,10 @@ class _AccessState(object):
 
         :param entry_point_group: The entrypoint for extensions.
         """
-        for ep in entry_points(group=entry_point_group):
+        # NOTE
+        # see above on load_entry_point_actions
+        eps = set(entry_points(group=entry_point_group))
+        for ep in eps:
             self.register_system_role(ep.load())
 
 

--- a/invenio_access/ext.py
+++ b/invenio_access/ext.py
@@ -2,15 +2,17 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Invenio module for common role based access control."""
 
-import pkg_resources
+
 import six
 from flask_principal import identity_loaded
+from invenio_base.utils import entry_points
 from werkzeug.utils import cached_property, import_string
 
 from . import config
@@ -103,7 +105,7 @@ class _AccessState(object):
 
         :param entry_point_group: The entrypoint for extensions.
         """
-        for ep in pkg_resources.iter_entry_points(group=entry_point_group):
+        for ep in entry_points(group=entry_point_group):
             self.register_action(ep.load())
 
     def register_system_role(self, system_role):
@@ -122,7 +124,7 @@ class _AccessState(object):
 
         :param entry_point_group: The entrypoint for extensions.
         """
-        for ep in pkg_resources.iter_entry_points(group=entry_point_group):
+        for ep in entry_points(group=entry_point_group):
             self.register_system_role(ep.load())
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2022 CERN.
-# Copyright (C) 2022-2024 Graz University of Technology.
+# Copyright (C) 2022-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -28,7 +28,7 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     invenio-accounts>=6.0.0,<7.0.0
-    invenio-base>=2.0.0,<3.0.0
+    invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
 
 [options.extras_require]

--- a/tests/test_invenio_access.py
+++ b/tests/test_invenio_access.py
@@ -62,10 +62,7 @@ def _mock_entry_points(group=None):
             ),
         ],
     }
-    names = data.keys() if group is None else [group]
-    for key in names:
-        for entry_point in data[key]:
-            yield entry_point
+    return data[group] if group else data
 
 
 def test_version():

--- a/tests/test_invenio_access.py
+++ b/tests/test_invenio_access.py
@@ -2,12 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Module tests."""
 
+from importlib.metadata import EntryPoint
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +17,6 @@ from flask import Flask
 from flask_principal import ActionNeed
 from invenio_db import db
 from invenio_db.utils import drop_alembic_version_table
-from pkg_resources import EntryPoint
 
 from invenio_access import InvenioAccess, current_access
 from invenio_access.permissions import SystemRoleNeed
@@ -41,12 +42,24 @@ def _mock_entry_points(group=None):
     """Mocking funtion of entrypoints."""
     data = {
         "invenio_access.actions": [
-            MockEntryPointAction("open", "demo.actions"),
-            MockEntryPointAction("close", "demo.actions"),
+            MockEntryPointAction(
+                name="open", value="demo.actions", group="invenio_access.actions"
+            ),
+            MockEntryPointAction(
+                name="close", value="demo.actions", group="invenio_access.actions"
+            ),
         ],
         "invenio_access.system_roles": [
-            MockEntryPointSystemRole("any_user", "demo.specrole"),
-            MockEntryPointSystemRole("authenticated_user", "demo.specrole"),
+            MockEntryPointSystemRole(
+                name="any_user",
+                value="demo.specrole",
+                group="invenio_access.system_roles",
+            ),
+            MockEntryPointSystemRole(
+                name="authenticated_user",
+                value="demo.specrole",
+                group="invenio_access.system_roles",
+            ),
         ],
     }
     names = data.keys() if group is None else [group]
@@ -98,7 +111,7 @@ def test_system_roles(base_app):
         assert len(current_access.system_roles) == 2
 
 
-@patch("pkg_resources.iter_entry_points", _mock_entry_points)
+@patch("importlib.metadata.entry_points", _mock_entry_points)
 def test_entrypoints():
     """Test if the entrypoints are registering actions and roles properly."""
     app = Flask("testapp")


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
