### PR TITLE
fix: better dependencies after communities tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v6.0.0 (released 2026-05-28)
+
+- chore(setup): bump dependencies
+- fix: better dependencies after communities tests
+
 Version v5.1.0 (released 2026-02-17)
 
 - feat: change role.name to role.id for identity.provides RoleNeed

--- a/invenio_access/__init__.py
+++ b/invenio_access/__init__.py
@@ -440,7 +440,7 @@ from .permissions import (
 )
 from .proxies import current_access
 
-__version__ = "5.1.0"
+__version__ = "6.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_access/alembic/f9843093f686_change_fk_accountsrole_to_string_upgrade.py
+++ b/invenio_access/alembic/f9843093f686_change_fk_accountsrole_to_string_upgrade.py
@@ -1,6 +1,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2026 CESNET z.s.p.o.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -18,12 +19,12 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "f9843093f686"
-down_revision = (
-    "f2522cdd5fcd",
-    "842a62b56e60",
-)  # Depends on invenio-accounts revision id (f2522cdd5fcd)
+down_revision = "842a62b56e60"
 branch_labels = ()
-depends_on = None
+depends_on = [
+    # invenio_accounts/alembic/f2522cdd5fcd_change_accountsrole_primary_key_to_string.py
+    "f2522cdd5fcd",
+]
 
 
 def upgrade():

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-accounts>=7.0.0,<8.0.0
+    invenio-accounts>=8.0.0,<9.0.0
     invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
 


### PR DESCRIPTION
### Description

Alembix migration fix to break circular dependency between access and accounts.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
